### PR TITLE
Add unit tests and CI for backend services

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,25 @@
+name: Backend Tests
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run tests
+        run: mvn -B -f backend/pom.xml test

--- a/backend/api-gateway/pom.xml
+++ b/backend/api-gateway/pom.xml
@@ -27,6 +27,12 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Lombok (version explicit; processing configured in parent) -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/api-gateway/src/test/java/com/easyshop/gateway/GatewayApplicationTests.java
+++ b/backend/api-gateway/src/test/java/com/easyshop/gateway/GatewayApplicationTests.java
@@ -1,0 +1,12 @@
+package com.easyshop.gateway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GatewayApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/auth-service/pom.xml
+++ b/backend/auth-service/pom.xml
@@ -66,6 +66,12 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/auth-service/src/test/java/com/easyshop/auth/web/AuthControllerTest.java
+++ b/backend/auth-service/src/test/java/com/easyshop/auth/web/AuthControllerTest.java
@@ -1,0 +1,37 @@
+package com.easyshop.auth.web;
+
+import com.easyshop.auth.jwt.JwtService;
+import com.easyshop.auth.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private UserRepository users;
+
+    @MockBean
+    private PasswordEncoder enc;
+
+    @MockBean
+    private JwtService jwt;
+
+    @Test
+    void healthEndpointWorks() throws Exception {
+        mvc.perform(get("/healthz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
+}

--- a/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
+++ b/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
@@ -1,0 +1,37 @@
+package com.easyshop.order.web;
+
+import com.easyshop.order.domain.OrderItemRepository;
+import com.easyshop.order.domain.OrderRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrderController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = "product.base-url=http://localhost")
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private OrderRepository orders;
+
+    @MockBean
+    private OrderItemRepository items;
+
+    @Test
+    void healthEndpointWorks() throws Exception {
+        mvc.perform(get("/healthz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
+}

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -66,6 +66,12 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/product-service/src/test/java/com/easyshop/product/web/ProductControllerTest.java
+++ b/backend/product-service/src/test/java/com/easyshop/product/web/ProductControllerTest.java
@@ -1,0 +1,31 @@
+package com.easyshop.product.web;
+
+import com.easyshop.product.domain.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProductController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private ProductRepository repo;
+
+    @Test
+    void healthEndpointWorks() throws Exception {
+        mvc.perform(get("/healthz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
+}


### PR DESCRIPTION
## Summary
- add basic Spring Boot tests for auth, product, order services and API gateway
- configure Maven tests to run in GitHub Actions

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b49b08610c832ebca05f148094acf5