### PR TITLE
feat: handle product service errors

### DIFF
--- a/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
@@ -6,10 +6,13 @@ import com.easyshop.order.domain.OrderRepository;
 import com.easyshop.order.domain.OrderItemRepository;
 import com.easyshop.order.web.dto.CheckoutDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 import java.math.BigDecimal;
 import java.security.Principal;
@@ -70,23 +73,38 @@ public class OrderController {
         BigDecimal total = BigDecimal.ZERO;
 
         for (CheckoutDto.Item it : dto.items()) {
-            var prod = http.get()
-                    .uri("/api/products/{id}", it.productId())
-                    .retrieve()
-                    .toEntity(Map.class)
-                    .getBody();
+            Map<String, Object> prod;
+            try {
+                prod = http.get()
+                        .uri("/api/products/{id}", it.productId())
+                        .retrieve()
+                        .onStatus(status -> status.value() == 404, (req, res) -> {
+                            throw new RestClientException("NOT_FOUND");
+                        })
+                        .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                            throw new RestClientException("SERVICE_UNAVAILABLE");
+                        })
+                        .body(Map.class);
 
-            if (prod == null) {
-                return ResponseEntity.status(404).body(Map.of("message", "Product not found"));
-            }
-
-            var res = http.post()
-                    .uri("/api/admin/products/{id}/reserve?qty={q}", it.productId(), it.quantity())
-                    .retrieve()
-                    .toBodilessEntity();
-
-            if (!res.getStatusCode().is2xxSuccessful()) {
-                return ResponseEntity.status(409).body(Map.of("message", "Stock not available"));
+                http.post()
+                        .uri("/api/admin/products/{id}/reserve?qty={q}", it.productId(), it.quantity())
+                        .retrieve()
+                        .onStatus(status -> status.value() == 409, (req, res) -> {
+                            throw new RestClientException("STOCK_NOT_AVAILABLE");
+                        })
+                        .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                            throw new RestClientException("SERVICE_UNAVAILABLE");
+                        })
+                        .toBodilessEntity();
+            } catch (RestClientException ex) {
+                return switch (ex.getMessage()) {
+                    case "NOT_FOUND" -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                            .body(Map.of("message", "Product not found"));
+                    case "STOCK_NOT_AVAILABLE" -> ResponseEntity.status(HttpStatus.CONFLICT)
+                            .body(Map.of("message", "Stock not available"));
+                    default -> ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                            .body(Map.of("message", "Product service unavailable"));
+                };
             }
 
             BigDecimal price = new BigDecimal(String.valueOf(prod.get("price")));


### PR DESCRIPTION
## Summary
- handle product API failures with `retrieve().onStatus` and `RestClientException`
- return 404, 409 or 503 codes with clear messages

## Testing
- `mvn -q -f backend/pom.xml -pl order-service -am test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b49b0740c0832ebdda0d4f1898cadc