### PR TITLE
Define Spring Boot Maven plugin version

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -60,6 +60,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Summary
- specify `${spring-boot.version}` for `spring-boot-maven-plugin` in backend aggregator POM

## Testing
- `mvn -Djava.net.preferIPv4Stack=true -f backend/pom.xml -pl common-security package -DskipTests` *(fails: Non-resolvable import POM: Could not transfer artifact, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a6704240832e8ac869e86ce71e2d