### PR TITLE
Include common-security module in service Docker builds

### DIFF
--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -2,11 +2,13 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml ./pom.xml
+COPY common-security/pom.xml ./common-security/pom.xml
+COPY common-security/src ./common-security/src
 COPY auth-service/pom.xml ./auth-service/pom.xml
-RUN mvn -q -DskipTests -f auth-service/pom.xml dependency:go-offline
+RUN mvn -q -DskipTests -f pom.xml -pl auth-service -am dependency:go-offline
 
 COPY auth-service/src ./auth-service/src
-RUN mvn -q -DskipTests -f auth-service/pom.xml package
+RUN mvn -q -DskipTests -f pom.xml -pl auth-service -am package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -2,11 +2,13 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml ./pom.xml
+COPY common-security/pom.xml ./common-security/pom.xml
+COPY common-security/src ./common-security/src
 COPY order-service/pom.xml ./order-service/pom.xml
-RUN mvn -q -DskipTests -f order-service/pom.xml dependency:go-offline
+RUN mvn -q -DskipTests -f pom.xml -pl order-service -am dependency:go-offline
 
 COPY order-service/src ./order-service/src
-RUN mvn -q -DskipTests -f order-service/pom.xml package
+RUN mvn -q -DskipTests -f pom.xml -pl order-service -am package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -2,11 +2,13 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml ./pom.xml
+COPY common-security/pom.xml ./common-security/pom.xml
+COPY common-security/src ./common-security/src
 COPY product-service/pom.xml ./product-service/pom.xml
-RUN mvn -q -DskipTests -f product-service/pom.xml dependency:go-offline
+RUN mvn -q -DskipTests -f pom.xml -pl product-service -am dependency:go-offline
 
 COPY product-service/src ./product-service/src
-RUN mvn -q -DskipTests -f product-service/pom.xml package
+RUN mvn -q -DskipTests -f pom.xml -pl product-service -am package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app


### PR DESCRIPTION
## Summary
- copy common-security module into auth, order and product Docker build contexts
- build services using aggregator-aware Maven commands so dependencies are resolved

## Testing
- ⚠️ `docker build -f backend/auth-service/Dockerfile backend` (Docker daemon unavailable)
- ⚠️ `mvn -q -DskipTests -f backend/pom.xml -pl auth-service -am dependency:go-offline` (network unreachable for Maven Central)


------
https://chatgpt.com/codex/tasks/task_e_68b4aa3b22c8832ea63cdea5219275b2