### PR TITLE
Use module-specific Maven builds in service Dockerfiles

### DIFF
--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -5,10 +5,10 @@ COPY pom.xml ./pom.xml
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY auth-service/pom.xml ./auth-service/pom.xml
-RUN mvn -q -DskipTests -f pom.xml -pl auth-service -am dependency:go-offline
+RUN mvn -q -DskipTests -f auth-service/pom.xml dependency:go-offline
 
 COPY auth-service/src ./auth-service/src
-RUN mvn -q -DskipTests -f pom.xml -pl auth-service -am package
+RUN mvn -q -DskipTests -f auth-service/pom.xml package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -5,10 +5,10 @@ COPY pom.xml ./pom.xml
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY order-service/pom.xml ./order-service/pom.xml
-RUN mvn -q -DskipTests -f pom.xml -pl order-service -am dependency:go-offline
+RUN mvn -q -DskipTests -f order-service/pom.xml dependency:go-offline
 
 COPY order-service/src ./order-service/src
-RUN mvn -q -DskipTests -f pom.xml -pl order-service -am package
+RUN mvn -q -DskipTests -f order-service/pom.xml package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -5,10 +5,10 @@ COPY pom.xml ./pom.xml
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY product-service/pom.xml ./product-service/pom.xml
-RUN mvn -q -DskipTests -f pom.xml -pl product-service -am dependency:go-offline
+RUN mvn -q -DskipTests -f product-service/pom.xml dependency:go-offline
 
 COPY product-service/src ./product-service/src
-RUN mvn -q -DskipTests -f pom.xml -pl product-service -am package
+RUN mvn -q -DskipTests -f product-service/pom.xml package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app


### PR DESCRIPTION
## Summary
- Update auth, product, and order service Dockerfiles to run Maven with module-specific POMs.
- Preserve parent `pom.xml` copy so module parent references resolve during builds.

## Testing
- ⚠️ `docker build -f backend/auth-service/Dockerfile backend` *(Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- ⚠️ `docker build -f backend/product-service/Dockerfile backend` *(Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- ⚠️ `docker build -f backend/order-service/Dockerfile backend` *(Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b4adade9b8832e912e8fa64a7dcd53