### PR TITLE
Ensure services install common-security before dependency resolution

### DIFF
--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -5,6 +5,7 @@ COPY pom.xml ./pom.xml
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY auth-service/pom.xml ./auth-service/pom.xml
+RUN mvn -q -DskipTests -f common-security/pom.xml install
 RUN mvn -q -DskipTests -f auth-service/pom.xml dependency:go-offline
 
 COPY auth-service/src ./auth-service/src

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -5,6 +5,7 @@ COPY pom.xml ./pom.xml
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY order-service/pom.xml ./order-service/pom.xml
+RUN mvn -q -DskipTests -f common-security/pom.xml install
 RUN mvn -q -DskipTests -f order-service/pom.xml dependency:go-offline
 
 COPY order-service/src ./order-service/src

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -5,6 +5,7 @@ COPY pom.xml ./pom.xml
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY product-service/pom.xml ./product-service/pom.xml
+RUN mvn -q -DskipTests -f common-security/pom.xml install
 RUN mvn -q -DskipTests -f product-service/pom.xml dependency:go-offline
 
 COPY product-service/src ./product-service/src


### PR DESCRIPTION
## Summary
- Install `common-security` into the local Maven repo in service Dockerfiles so dependency resolution succeeds

## Testing
- `docker build -t auth-service-test -f backend/auth-service/Dockerfile backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b2d99874832eb9f1ed77e19024cf