### PR TITLE
Inject JwtAuthFilter bean in security configuration

### DIFF
--- a/backend/common-security/src/main/java/com/easyshop/common/security/SecurityConfig.java
+++ b/backend/common-security/src/main/java/com/easyshop/common/security/SecurityConfig.java
@@ -12,7 +12,12 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity h, @Value("${jwt.secret}") String secret) throws Exception {
+    public JwtAuthFilter jwtAuthFilter(@Value("${jwt.secret}") String secret) {
+        return new JwtAuthFilter(secret);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity h, JwtAuthFilter jwtAuthFilter) throws Exception {
         h.csrf(cs -> cs.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(r -> r
@@ -20,7 +25,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthFilter(secret), BasicAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthFilter, BasicAuthenticationFilter.class);
         return h.build();
     }
 }


### PR DESCRIPTION
## Summary
- provide JwtAuthFilter as a Spring bean using jwt.secret
- wire SecurityFilterChain with injected JwtAuthFilter

## Testing
- `mvn -q -DskipTests -pl backend/api-gateway -f backend/pom.xml spring-boot:test` *(fails: Non-resolvable import POM: Could not transfer artifact spring-boot-dependencies due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b58f17e4832ea15b4ab05015d9f3