### PR TITLE
Install parent POM during auth-service Docker build

### DIFF
--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml ./pom.xml
+RUN mvn -q -N -DskipTests install
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY auth-service/pom.xml ./auth-service/pom.xml


### PR DESCRIPTION
## Summary
- ensure backend parent POM is installed in auth-service Docker build before module dependencies

## Testing
- `mvn -q -N -DskipTests install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ba645928832ea8db287da637e78d