### PR TITLE
chore: install parent pom before building api gateway

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY pom.xml ./pom.xml
+RUN mvn -q -N -DskipTests install
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
 RUN mvn -q -DskipTests -f api-gateway/pom.xml dependency:go-offline
 COPY api-gateway/src ./api-gateway/src


### PR DESCRIPTION
## Summary
- ensure root Maven POM is installed in Docker build for the API gateway

## Testing
- `mvn -q -f backend/api-gateway/pom.xml test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bfaac4fc832ebb5259ba421397cf