### PR TITLE
build(product-service): install parent pom during image build

### DIFF
--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml ./pom.xml
+RUN mvn -q -N -DskipTests install
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY product-service/pom.xml ./product-service/pom.xml


### PR DESCRIPTION
## Summary
- Install parent Maven POM before building the product-service image to cache dependencies

## Testing
- `mvn -q -pl product-service -am test` *(fails: Non-resolvable import POM due to unreachable Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bfaa98a8832e85fede960c780759