### PR TITLE
build: install root pom before building common security

### DIFF
--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml ./pom.xml
+RUN mvn -q -N -DskipTests install
 COPY common-security/pom.xml ./common-security/pom.xml
 COPY common-security/src ./common-security/src
 COPY order-service/pom.xml ./order-service/pom.xml


### PR DESCRIPTION
## Summary
- install root pom during order-service image build before building common-security

## Testing
- `mvn -q -N -DskipTests install` (fails: Could not transfer artifact: Network is unreachable)
- `docker --version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b4bfa9c1dc832e9259c9713143bcb1