### PR TITLE
Align auth service port with compose config

### DIFF
--- a/backend/auth-service/src/main/resources/application.yml
+++ b/backend/auth-service/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-server: { port: 9001 }
+server: { port: 8080 }
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}

--- a/infra/prod/docker-compose.prod.yml
+++ b/infra/prod/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - AUTH_URL=${AUTH_URL:-http://auth-service:8080}
+      - AUTH_URL=http://auth-service:8080
       - PRODUCT_URL=${PRODUCT_URL:-http://product-service:8080}
       - ORDER_URL=${ORDER_URL:-http://order-service:8080}
     depends_on:


### PR DESCRIPTION
## Summary
- Serve auth-service on port 8080
- Point api-gateway to auth-service's new port

## Testing
- `docker-compose -f infra/prod/docker-compose.prod.yml up -d --build` *(fails: Connection aborted, FileNotFoundError(2, 'No such file or directory'))*
- `mvn -pl auth-service -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c6fb1d94832e87ef51dcefbd182a