### PR TITLE
Add frontend internationalization with language switcher

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "easyshop-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "i18next": "^25.4.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^15.7.3",
         "react-router-dom": "^6.26.1"
       },
       "devDependencies": {
@@ -246,6 +248,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1201,6 +1212,46 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.4.2.tgz",
+      "integrity": "sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1335,6 +1386,32 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
+      "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -1529,6 +1606,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,12 +9,14 @@
     "preview": "vite preview --port 5173"
   },
   "dependencies": {
+    "i18next": "^25.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-i18next": "^15.7.3",
     "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
-    "vite": "^5.4.3",
-    "@vitejs/plugin-react": "^4.3.1"
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.3"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1,0 +1,6 @@
+{
+  "nav": {"shop": "Shop", "account": "Account", "admin": "Admin"},
+  "shop": {"catalog": "Catalog", "stock": "stock", "buy_one": "Buy 1 pc.", "login_first": "Log in first on Account tab", "order_done": "Order placed"},
+  "account": {"login": "Login", "register": "Register", "email": "Email", "password": "Password", "password_min": "Password (min. 8)", "submit_login": "Sign in", "create_account": "Create account", "login_success": "Logged in", "register_success": "Done! Now log in."},
+  "admin": {"create_product": "Create product", "name": "Name", "price": "Price", "stock": "Stock", "description": "Description", "create": "Create", "catalog": "Catalog", "delete": "Delete", "confirm_delete": "Delete?"}
+}

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -1,0 +1,6 @@
+{
+  "nav": {"shop": "Магазин", "account": "Аккаунт", "admin": "Админ"},
+  "shop": {"catalog": "Каталог", "stock": "сток", "buy_one": "Купить 1 шт.", "login_first": "Сначала войдите во вкладке Аккаунт", "order_done": "Заказ оформлен"},
+  "account": {"login": "Вход", "register": "Регистрация", "email": "Email", "password": "Пароль", "password_min": "Пароль (мин. 8)", "submit_login": "Войти", "create_account": "Создать аккаунт", "login_success": "Вход выполнен", "register_success": "Готово! Теперь войдите."},
+  "admin": {"create_product": "Создать товар", "name": "Название", "price": "Цена", "stock": "Сток", "description": "Описание", "create": "Создать", "catalog": "Каталог", "delete": "Удалить", "confirm_delete": "Удалить?"}
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,8 +1,16 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import i18n from 'i18next'
+import { I18nextProvider, useTranslation } from 'react-i18next'
+import en from './i18n/en.json'
+import ru from './i18n/ru.json'
 import Shop from './pages/Shop.jsx'
 import Account from './pages/Account.jsx'
 import Admin from './pages/Admin.jsx'
-function Layout(){return (<div style={{fontFamily:'system-ui'}}><header style={{background:'#fff',borderBottom:'1px solid #eee',padding:12}}><b>EasyShop</b> — <Link to="/shop">Магазин</Link> | <Link to="/account">Аккаунт</Link> | <Link to="/admin">Админ</Link></header><div style={{maxWidth:960, margin:'0 auto', padding:16}}><Routes><Route path="/" element={<Shop/>}/><Route path="/shop" element={<Shop/>}/><Route path="/account" element={<Account/>}/><Route path="/admin" element={<Admin/>}/></Routes></div></div>)}
-createRoot(document.getElementById('root')).render(<BrowserRouter><Layout/></BrowserRouter>)
+
+i18n.init({ resources:{ en:{ translation:en }, ru:{ translation:ru } }, lng:localStorage.getItem('lang')||'ru', interpolation:{ escapeValue:false } })
+
+function Layout(){const { t,i18n } = useTranslation(); function change(e){ const l=e.target.value; i18n.changeLanguage(l); localStorage.setItem('lang',l) } return (<div style={{fontFamily:'system-ui'}}><header style={{background:'#fff',borderBottom:'1px solid #eee',padding:12}}><b>EasyShop</b> — <Link to="/shop">{t('nav.shop')}</Link> | <Link to="/account">{t('nav.account')}</Link> | <Link to="/admin">{t('nav.admin')}</Link> <select value={i18n.language} onChange={change}><option value="ru">RU</option><option value="en">EN</option></select></header><div style={{maxWidth:960, margin:'0 auto', padding:16}}><Routes><Route path="/" element={<Shop/>}/><Route path="/shop" element={<Shop/>}/><Route path="/account" element={<Account/>}/><Route path="/admin" element={<Admin/>}/></Routes></div></div>)}
+
+createRoot(document.getElementById('root')).render(<I18nextProvider i18n={i18n}><BrowserRouter><Layout/></BrowserRouter></I18nextProvider>)

--- a/frontend/src/pages/Account.jsx
+++ b/frontend/src/pages/Account.jsx
@@ -1,6 +1,43 @@
 import React, { useState } from 'react'
 import { api, setToken } from '../lib/api'
-export default function Account(){const [loginMsg,setLoginMsg]=useState(''); const [regMsg,setRegMsg]=useState('')
-  async function onLogin(e){ e.preventDefault(); setLoginMsg(''); try{ const j = await api('/auth/login',{method:'POST',body:JSON.stringify({email:e.target.email.value, password:e.target.password.value})}); setToken(j.token); setLoginMsg('Вход выполнен') } catch(err){ setLoginMsg(err.message) } }
-  async function onRegister(e){ e.preventDefault(); setRegMsg(''); try{ await api('/auth/register',{method:'POST',body:JSON.stringify({email:e.target.email.value, password:e.target.password.value})}); setRegMsg('Готово! Теперь войдите.') } catch(err){ setRegMsg(err.message) } }
-  return (<div><div style={{border:'1px solid #eee',borderRadius:14,padding:16,marginBottom:16}}><h2>Вход</h2><form onSubmit={onLogin}><input name="email" placeholder="Email" required/><br/><br/><input name="password" type="password" placeholder="Пароль" required/><br/><br/><button>Войти</button> <span>{loginMsg}</span></form></div><div style={{border:'1px solid #eee',borderRadius:14,padding:16}}><h2>Регистрация</h2><form onSubmit={onRegister}><input name="email" placeholder="Email" required/><br/><br/><input name="password" type="password" placeholder="Пароль (мин. 8)" minLength={8} required/><br/><br/><button>Создать аккаунт</button> <span>{regMsg}</span></form></div></div>) }
+import { useTranslation } from 'react-i18next'
+
+export default function Account(){
+  const { t } = useTranslation()
+  const [loginMsg,setLoginMsg]=useState('')
+  const [regMsg,setRegMsg]=useState('')
+  async function onLogin(e){
+    e.preventDefault(); setLoginMsg('')
+    try{ const j = await api('/auth/login',{method:'POST',body:JSON.stringify({email:e.target.email.value, password:e.target.password.value})}); setToken(j.token); setLoginMsg(t('account.login_success')) }
+    catch(err){ setLoginMsg(err.message) }
+  }
+  async function onRegister(e){
+    e.preventDefault(); setRegMsg('')
+    try{ await api('/auth/register',{method:'POST',body:JSON.stringify({email:e.target.email.value, password:e.target.password.value})}); setRegMsg(t('account.register_success')) }
+    catch(err){ setRegMsg(err.message) }
+  }
+  return (
+    <div>
+      <div style={{border:'1px solid #eee',borderRadius:14,padding:16,marginBottom:16}}>
+        <h2>{t('account.login')}</h2>
+        <form onSubmit={onLogin}>
+          <input name="email" placeholder={t('account.email')} required/>
+          <br/><br/>
+          <input name="password" type="password" placeholder={t('account.password')} required/>
+          <br/><br/>
+          <button>{t('account.submit_login')}</button> <span>{loginMsg}</span>
+        </form>
+      </div>
+      <div style={{border:'1px solid #eee',borderRadius:14,padding:16}}>
+        <h2>{t('account.register')}</h2>
+        <form onSubmit={onRegister}>
+          <input name="email" placeholder={t('account.email')} required/>
+          <br/><br/>
+          <input name="password" type="password" placeholder={t('account.password_min')} minLength={8} required/>
+          <br/><br/>
+          <button>{t('account.create_account')}</button> <span>{regMsg}</span>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,6 +1,53 @@
 import React, { useEffect, useState } from 'react'
 import { api } from '../lib/api'
-export default function Admin(){const [list,setList]=useState([]); async function load(){ try{ const l = await api('/products'); setList(l) } catch(e){ alert(e.message) } } useEffect(()=>{ load() },[])
-  async function create(e){ e.preventDefault(); const data = { name:e.target.name.value, description:e.target.description.value, price:Number(e.target.price.value), stock:Number(e.target.stock.value) }; try{ await api('/admin/products',{ method:'POST', body:JSON.stringify(data) }); e.target.reset(); load() } catch(e){ alert(e.message) } }
-  async function del(id){ if(!confirm('Удалить?')) return; try{ await api('/admin/products/'+id,{ method:'DELETE' }); load() } catch(e){ alert(e.message) } }
-  return (<div><div style={{border:'1px solid #eee',borderRadius:14,padding:16, marginBottom:16}}><h2>Создать товар</h2><form onSubmit={create}><input name="name" placeholder="Название" required/> <input name="price" type="number" step="0.01" defaultValue="0"/> <input name="stock" type="number" defaultValue="0"/><br/><br/><textarea name="description" placeholder="Описание" rows="3" style={{width:'100%'}}></textarea><br/><br/><button>Создать</button></form></div><div style={{border:'1px solid #eee',borderRadius:14,padding:16}}><h2>Каталог</h2><table style={{width:'100%',borderCollapse:'collapse'}}><thead><tr><th>Название</th><th>Цена</th><th>Сток</th><th></th></tr></thead><tbody>{list.map(p=>(<tr key={p.id}><td>{p.name}</td><td>{Number(p.price).toFixed(2)} ₽</td><td>{p.stock}</td><td style={{textAlign:'right'}}><button onClick={()=>del(p.id)}>Удалить</button></td></tr>))}</tbody></table></div></div>) }
+import { useTranslation } from 'react-i18next'
+
+export default function Admin(){
+  const { t } = useTranslation()
+  const [list,setList]=useState([])
+  async function load(){ try{ const l = await api('/products'); setList(l) } catch(e){ alert(e.message) } }
+  useEffect(()=>{ load() },[])
+  async function create(e){
+    e.preventDefault()
+    const data = { name:e.target.name.value, description:e.target.description.value, price:Number(e.target.price.value), stock:Number(e.target.stock.value) }
+    try{ await api('/admin/products',{ method:'POST', body:JSON.stringify(data) }); e.target.reset(); load() }
+    catch(e){ alert(e.message) }
+  }
+  async function del(id){
+    if(!confirm(t('admin.confirm_delete'))) return
+    try{ await api('/admin/products/'+id,{ method:'DELETE' }); load() }
+    catch(e){ alert(e.message) }
+  }
+  return (
+    <div>
+      <div style={{border:'1px solid #eee',borderRadius:14,padding:16, marginBottom:16}}>
+        <h2>{t('admin.create_product')}</h2>
+        <form onSubmit={create}>
+          <input name="name" placeholder={t('admin.name')} required/> <input name="price" type="number" step="0.01" defaultValue="0"/> <input name="stock" type="number" defaultValue="0"/>
+          <br/><br/>
+          <textarea name="description" placeholder={t('admin.description')} rows="3" style={{width:'100%'}}></textarea>
+          <br/><br/>
+          <button>{t('admin.create')}</button>
+        </form>
+      </div>
+      <div style={{border:'1px solid #eee',borderRadius:14,padding:16}}>
+        <h2>{t('admin.catalog')}</h2>
+        <table style={{width:'100%',borderCollapse:'collapse'}}>
+          <thead>
+            <tr><th>{t('admin.name')}</th><th>{t('admin.price')}</th><th>{t('admin.stock')}</th><th></th></tr>
+          </thead>
+          <tbody>
+            {list.map(p=>(
+              <tr key={p.id}>
+                <td>{p.name}</td>
+                <td>{Number(p.price).toFixed(2)} ₽</td>
+                <td>{p.stock}</td>
+                <td style={{textAlign:'right'}}><button onClick={()=>del(p.id)}>{t('admin.delete')}</button></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Shop.jsx
+++ b/frontend/src/pages/Shop.jsx
@@ -1,6 +1,31 @@
 import React, { useEffect, useState } from 'react'
 import { api, getToken } from '../lib/api'
-export default function Shop(){const [list,setList]=useState([])
+import { useTranslation } from 'react-i18next'
+
+export default function Shop(){
+  const { t } = useTranslation()
+  const [list,setList]=useState([])
   useEffect(()=>{ api('/products').then(setList).catch(e=>alert(e.message)) },[])
-  async function buyOne(p){ if (!getToken()){ alert('Сначала войдите во вкладке Аккаунт'); return } try{ await api('/orders/checkout', { method:'POST', body: JSON.stringify({ items: [{ productId: p.id, quantity: 1 }] }) }); alert('Заказ оформлен') } catch(e){ alert(e.message) } }
-  return (<div><h2>Каталог</h2><div style={{display:'grid',gridTemplateColumns:'repeat(auto-fill,minmax(240px,1fr))', gap:12}}>{list.map(p=>(<div key={p.id} style={{border:'1px solid #eee',borderRadius:14,padding:16}}><div style={{display:'flex',justifyContent:'space-between'}}><b>{p.name}</b><span>сток: {p.stock}</span></div><div style={{color:'#666'}}>{p.description||'—'}</div><div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}><div><b>{Number(p.price).toFixed(2)} ₽</b></div><button onClick={()=>buyOne(p)}>Купить 1 шт.</button></div></div>))}</div></div>) }
+  async function buyOne(p){
+    if (!getToken()){ alert(t('shop.login_first')); return }
+    try{ await api('/orders/checkout', { method:'POST', body: JSON.stringify({ items: [{ productId: p.id, quantity: 1 }] }) }); alert(t('shop.order_done')) }
+    catch(e){ alert(e.message) }
+  }
+  return (
+    <div>
+      <h2>{t('shop.catalog')}</h2>
+      <div style={{display:'grid',gridTemplateColumns:'repeat(auto-fill,minmax(240px,1fr))', gap:12}}>
+        {list.map(p=>(
+          <div key={p.id} style={{border:'1px solid #eee',borderRadius:14,padding:16}}>
+            <div style={{display:'flex',justifyContent:'space-between'}}><b>{p.name}</b><span>{t('shop.stock')}: {p.stock}</span></div>
+            <div style={{color:'#666'}}>{p.description||'—'}</div>
+            <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+              <div><b>{Number(p.price).toFixed(2)} ₽</b></div>
+              <button onClick={()=>buyOne(p)}>{t('shop.buy_one')}</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add i18next and react-i18next dependencies
- introduce English and Russian translation files
- initialize i18next, replace hardcoded strings, and add language switcher

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b54b3d5c08832e8b3f7647332d07e7