### PR TITLE
feat: add global error handling and trace id logging

### DIFF
--- a/backend/api-gateway/src/main/java/com/easyshop/gateway/web/ApiResponseDto.java
+++ b/backend/api-gateway/src/main/java/com/easyshop/gateway/web/ApiResponseDto.java
@@ -1,0 +1,5 @@
+package com.easyshop.gateway.web;
+
+public record ApiResponseDto(boolean ok, String message) {
+}
+

--- a/backend/api-gateway/src/main/java/com/easyshop/gateway/web/GlobalExceptionHandler.java
+++ b/backend/api-gateway/src/main/java/com/easyshop/gateway/web/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.easyshop.gateway.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    public Mono<ResponseEntity<ApiResponseDto>> handleValidation(WebExchangeBindException ex) {
+        String msg = ex.getAllErrors().stream()
+                .findFirst()
+                .map(err -> err.getDefaultMessage())
+                .orElse("Validation error");
+        log.warn("Validation failed: {}", msg);
+        return Mono.just(ResponseEntity.badRequest().body(new ApiResponseDto(false, msg)));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public Mono<ResponseEntity<ApiResponseDto>> handleDatabase(DataAccessException ex) {
+        log.error("Database error", ex);
+        return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Database error")));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public Mono<ResponseEntity<ApiResponseDto>> handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+        return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Unexpected error")));
+    }
+}
+

--- a/backend/api-gateway/src/main/java/com/easyshop/gateway/web/TraceIdWebFilter.java
+++ b/backend/api-gateway/src/main/java/com/easyshop/gateway/web/TraceIdWebFilter.java
@@ -1,0 +1,31 @@
+package com.easyshop.gateway.web;
+
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TraceIdWebFilter implements WebFilter {
+
+    private static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String traceId = exchange.getRequest().getHeaders().getFirst(TRACE_ID_HEADER);
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString();
+        }
+        MDC.put("traceId", traceId);
+        exchange.getResponse().getHeaders().add(TRACE_ID_HEADER, traceId);
+        return chain.filter(exchange).doFinally(signalType -> MDC.remove("traceId"));
+    }
+}
+

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server: { port: 8080 }
 spring:
+  application: { name: api-gateway }
   cloud:
     gateway:
       routes:
@@ -12,4 +13,8 @@ spring:
         - id: orders
           uri: ${ORDER_URL:http://order-service:9003}
           predicates: [ Path=/api/orders/** ]
+
+logging:
+  pattern:
+    level: "%5p [trace:%X{traceId}]"
           

--- a/backend/auth-service/src/main/java/com/easyshop/auth/web/GlobalExceptionHandler.java
+++ b/backend/auth-service/src/main/java/com/easyshop/auth/web/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.easyshop.auth.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDto> handleValidation(MethodArgumentNotValidException ex) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .findFirst()
+                .orElse("Validation error");
+        log.warn("Validation failed: {}", msg);
+        return ResponseEntity.badRequest().body(new ApiResponseDto(false, msg));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ApiResponseDto> handleDatabase(DataAccessException ex) {
+        log.error("Database error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Database error"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto> handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Unexpected error"));
+    }
+}
+

--- a/backend/auth-service/src/main/resources/application.yml
+++ b/backend/auth-service/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server: { port: 8080 }
 spring:
+  application: { name: auth-service }
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
@@ -7,4 +8,8 @@ spring:
   jpa: { "hibernate": { "ddl-auto": "validate" }, "properties": { "hibernate": { "dialect": "org.hibernate.dialect.PostgreSQLDialect" } } }
   flyway: { "enabled": true,"locations": "classpath:db/migration","schemas": "easyshop","create-schemas": true }
 jwt: { "secret": "${JWT_SECRET:change-me}","ttlMinutes": 60 }
+
+logging:
+  pattern:
+    level: "%5p [trace:%X{traceId}]"
 

--- a/backend/common-security/src/main/java/com/easyshop/common/security/TraceIdFilter.java
+++ b/backend/common-security/src/main/java/com/easyshop/common/security/TraceIdFilter.java
@@ -1,0 +1,41 @@
+package com.easyshop.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String traceId = request.getHeader(TRACE_ID_HEADER);
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString();
+        }
+        MDC.put("traceId", traceId);
+        response.addHeader(TRACE_ID_HEADER, traceId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove("traceId");
+        }
+    }
+}
+

--- a/backend/order-service/src/main/java/com/easyshop/order/web/ApiResponseDto.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/ApiResponseDto.java
@@ -1,0 +1,5 @@
+package com.easyshop.order.web;
+
+public record ApiResponseDto(boolean ok, String message) {
+}
+

--- a/backend/order-service/src/main/java/com/easyshop/order/web/GlobalExceptionHandler.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.easyshop.order.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDto> handleValidation(MethodArgumentNotValidException ex) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .findFirst()
+                .orElse("Validation error");
+        log.warn("Validation failed: {}", msg);
+        return ResponseEntity.badRequest().body(new ApiResponseDto(false, msg));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ApiResponseDto> handleDatabase(DataAccessException ex) {
+        log.error("Database error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Database error"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto> handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Unexpected error"));
+    }
+}
+

--- a/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
@@ -35,13 +35,13 @@ public class OrderController {
     }
 
     @GetMapping("/healthz")
-    public Map<String, Object> health() {
-        return Map.of("ok", true);
+    public ApiResponseDto health() {
+        return new ApiResponseDto(true, null);
     }
 
     @GetMapping("/readyz")
-    public Map<String, Object> ready() {
-        return Map.of("ok", true);
+    public ApiResponseDto ready() {
+        return new ApiResponseDto(true, null);
     }
 
     @GetMapping("/api/orders")

--- a/backend/order-service/src/main/resources/application.yml
+++ b/backend/order-service/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server: { port: 9003 }
 spring:
+  application: { name: order-service }
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
@@ -9,4 +10,8 @@ spring:
 jwt: { "secret": "${JWT_SECRET:change-me}","ttlMinutes": 60 }
 product:
   base-url: ${PRODUCT_BASE_URL:http://product-service:9002}
+
+logging:
+  pattern:
+    level: "%5p [trace:%X{traceId}]"
 

--- a/backend/product-service/src/main/java/com/easyshop/product/web/GlobalExceptionHandler.java
+++ b/backend/product-service/src/main/java/com/easyshop/product/web/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.easyshop.product.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDto> handleValidation(MethodArgumentNotValidException ex) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .findFirst()
+                .orElse("Validation error");
+        log.warn("Validation failed: {}", msg);
+        return ResponseEntity.badRequest().body(new ApiResponseDto(false, msg));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ApiResponseDto> handleDatabase(DataAccessException ex) {
+        log.error("Database error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Database error"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto> handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponseDto(false, "Unexpected error"));
+    }
+}
+

--- a/backend/product-service/src/main/resources/application.yml
+++ b/backend/product-service/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server: { port: 9002 }
 spring:
+  application: { name: product-service }
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
@@ -7,4 +8,8 @@ spring:
   jpa: { "hibernate": { "ddl-auto": "validate" }, "properties": { "hibernate": { "dialect": "org.hibernate.dialect.PostgreSQLDialect" } } }
   flyway: { "enabled": true,"locations": "classpath:db/migration","schemas": "easyshop","create-schemas": true }
 jwt: { "secret": "${JWT_SECRET:change-me}","ttlMinutes": 60 }
+
+logging:
+  pattern:
+    level: "%5p [trace:%X{traceId}]"
 


### PR DESCRIPTION
## Summary
- add GlobalExceptionHandler to all services for validation, database and unexpected errors
- log requests with trace id correlation and standard ApiResponseDto
- expose trace id in logs and configurations for gateway and services

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b54b46e81c832eab0efacb0c2fd213