### PR TITLE
Add Lombok dependency to common-security module

### DIFF
--- a/backend/common-security/pom.xml
+++ b/backend/common-security/pom.xml
@@ -40,5 +40,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.32</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- Add Lombok as a provided optional dependency in the common-security module

## Testing
- `mvn -f backend/pom.xml -pl common-security -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b54ff53df8832e8804fe7fc683000f