### PR TITLE
Add password encoder configuration

### DIFF
--- a/backend/auth-service/src/main/java/com/easyshop/auth/AuthConfig.java
+++ b/backend/auth-service/src/main/java/com/easyshop/auth/AuthConfig.java
@@ -1,0 +1,15 @@
+package com.easyshop.auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## Summary
- configure auth service with BCrypt password encoder

## Testing
- `mvn -pl auth-service test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5500ad424832e95dceaec159d190b