### PR TITLE
refactor: centralize ApiResponseDto in common-security

### DIFF
--- a/backend/api-gateway/pom.xml
+++ b/backend/api-gateway/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.easyshop</groupId>
+            <artifactId>common-security</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/backend/api-gateway/src/main/java/com/easyshop/gateway/web/ApiResponseDto.java
+++ b/backend/api-gateway/src/main/java/com/easyshop/gateway/web/ApiResponseDto.java
@@ -1,5 +1,0 @@
-package com.easyshop.gateway.web;
-
-public record ApiResponseDto(boolean ok, String message) {
-}
-

--- a/backend/api-gateway/src/main/java/com/easyshop/gateway/web/GlobalExceptionHandler.java
+++ b/backend/api-gateway/src/main/java/com/easyshop/gateway/web/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.easyshop.gateway.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;

--- a/backend/auth-service/src/main/java/com/easyshop/auth/web/ApiResponseDto.java
+++ b/backend/auth-service/src/main/java/com/easyshop/auth/web/ApiResponseDto.java
@@ -1,4 +1,0 @@
-package com.easyshop.auth.web;
-
-public record ApiResponseDto(boolean ok, String message) {
-}

--- a/backend/auth-service/src/main/java/com/easyshop/auth/web/AuthController.java
+++ b/backend/auth-service/src/main/java/com/easyshop/auth/web/AuthController.java
@@ -1,5 +1,6 @@
 package com.easyshop.auth.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import com.easyshop.auth.service.AuthService;
 import jakarta.validation.*;
 import org.springframework.http.*;

--- a/backend/auth-service/src/main/java/com/easyshop/auth/web/GlobalExceptionHandler.java
+++ b/backend/auth-service/src/main/java/com/easyshop/auth/web/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.easyshop.auth.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;

--- a/backend/common-security/src/main/java/com/easyshop/common/web/ApiResponseDto.java
+++ b/backend/common-security/src/main/java/com/easyshop/common/web/ApiResponseDto.java
@@ -1,4 +1,4 @@
-package com.easyshop.product.web;
+package com.easyshop.common.web;
 
 public record ApiResponseDto(boolean ok, String message) {
 }

--- a/backend/order-service/src/main/java/com/easyshop/order/web/ApiResponseDto.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/ApiResponseDto.java
@@ -1,5 +1,0 @@
-package com.easyshop.order.web;
-
-public record ApiResponseDto(boolean ok, String message) {
-}
-

--- a/backend/order-service/src/main/java/com/easyshop/order/web/GlobalExceptionHandler.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.easyshop.order.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;

--- a/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
@@ -1,5 +1,6 @@
 package com.easyshop.order.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import com.easyshop.order.service.OrderService;
 import com.easyshop.order.service.OrderService.ProductNotFoundException;
 import com.easyshop.order.service.OrderService.ServiceUnavailableException;

--- a/backend/product-service/src/main/java/com/easyshop/product/web/GlobalExceptionHandler.java
+++ b/backend/product-service/src/main/java/com/easyshop/product/web/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.easyshop.product.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;

--- a/backend/product-service/src/main/java/com/easyshop/product/web/ProductController.java
+++ b/backend/product-service/src/main/java/com/easyshop/product/web/ProductController.java
@@ -1,5 +1,6 @@
 package com.easyshop.product.web;
 
+import com.easyshop.common.web.ApiResponseDto;
 import com.easyshop.product.domain.Product;
 import com.easyshop.product.service.ProductService;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
## Summary
- centralize ApiResponseDto into common-security module
- import the shared ApiResponseDto in controllers and handlers
- add common-security dependency to the api-gateway module

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b550103094832eb61c77d68a1b863e