### PR TITLE
Refactor controller method names for clarity

### DIFF
--- a/backend/auth-service/src/main/java/com/easyshop/auth/web/AuthController.java
+++ b/backend/auth-service/src/main/java/com/easyshop/auth/web/AuthController.java
@@ -14,17 +14,17 @@ public class AuthController {
     }
 
     @GetMapping("/healthz")
-    public ApiResponseDto h() {
+    public ApiResponseDto health() {
         return new ApiResponseDto(true, null);
     }
 
     @GetMapping("/readyz")
-    public ApiResponseDto r() {
+    public ApiResponseDto ready() {
         return new ApiResponseDto(true, null);
     }
 
     @PostMapping("/api/auth/register")
-    public ResponseEntity<ApiResponseDto> reg(@Valid @RequestBody AuthDto d) {
+    public ResponseEntity<ApiResponseDto> register(@Valid @RequestBody AuthDto d) {
         if (!service.register(d))
             return ResponseEntity.badRequest().body(new ApiResponseDto(false, "Email already used"));
         return ResponseEntity.ok(new ApiResponseDto(true, null));
@@ -39,7 +39,7 @@ public class AuthController {
     }
 
     @GetMapping("/api/auth/verify")
-    public ResponseEntity<ApiResponseDto> v() {
+    public ResponseEntity<ApiResponseDto> verify() {
         return ResponseEntity.ok(new ApiResponseDto(true, null));
     }
 }

--- a/backend/auth-service/src/test/java/com/easyshop/auth/web/AuthControllerTest.java
+++ b/backend/auth-service/src/test/java/com/easyshop/auth/web/AuthControllerTest.java
@@ -34,4 +34,11 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok").value(true));
     }
+
+    @Test
+    void readyEndpointWorks() throws Exception {
+        mvc.perform(get("/readyz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
 }

--- a/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
+++ b/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
@@ -34,4 +34,11 @@ class OrderControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok").value(true));
     }
+
+    @Test
+    void readyEndpointWorks() throws Exception {
+        mvc.perform(get("/readyz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
 }

--- a/backend/product-service/src/main/java/com/easyshop/product/web/ProductController.java
+++ b/backend/product-service/src/main/java/com/easyshop/product/web/ProductController.java
@@ -18,12 +18,12 @@ public class ProductController {
     }
 
     @GetMapping("/healthz")
-    public ApiResponseDto h() {
+    public ApiResponseDto health() {
         return new ApiResponseDto(true, null);
     }
 
     @GetMapping("/readyz")
-    public ApiResponseDto r() {
+    public ApiResponseDto ready() {
         return new ApiResponseDto(true, null);
     }
 
@@ -44,19 +44,19 @@ public class ProductController {
     }
 
     @PutMapping("/api/admin/products/{id}")
-    public ResponseEntity<?> upd(@PathVariable Long id, @Valid @RequestBody ProductUpdateDto b) {
+    public ResponseEntity<?> updateProduct(@PathVariable Long id, @Valid @RequestBody ProductUpdateDto b) {
         return service.update(id, b)
                 .<ResponseEntity<?>>map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/api/admin/products/{id}")
-    public ResponseEntity<?> del(@PathVariable Long id) {
+    public ResponseEntity<?> deleteProduct(@PathVariable Long id) {
         return service.delete(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
     }
 
     @PostMapping("/api/admin/products/{id}/reserve")
-    public ResponseEntity<ApiResponseDto> res(@PathVariable Long id, @RequestParam int qty) {
+    public ResponseEntity<ApiResponseDto> reserveStock(@PathVariable Long id, @RequestParam int qty) {
         return switch (service.reserve(id, qty)) {
             case OK -> ResponseEntity.ok(new ApiResponseDto(true, null));
             case NOT_ENOUGH_STOCK -> ResponseEntity.status(409).body(new ApiResponseDto(false, "Not enough stock"));

--- a/backend/product-service/src/test/java/com/easyshop/product/web/ProductControllerTest.java
+++ b/backend/product-service/src/test/java/com/easyshop/product/web/ProductControllerTest.java
@@ -28,4 +28,11 @@ class ProductControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok").value(true));
     }
+
+    @Test
+    void readyEndpointWorks() throws Exception {
+        mvc.perform(get("/readyz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
 }


### PR DESCRIPTION
## Summary
- rename controller methods to descriptive names
- add readiness endpoint tests for services

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5501489f8832e97e8b3c0d47fcca6