### PR TITLE
Refactor order service to use dedicated DTOs

### DIFF
--- a/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/OrderController.java
@@ -5,12 +5,13 @@ import com.easyshop.order.service.OrderService.ProductNotFoundException;
 import com.easyshop.order.service.OrderService.ServiceUnavailableException;
 import com.easyshop.order.service.OrderService.StockNotAvailableException;
 import com.easyshop.order.web.dto.CheckoutDto;
+import com.easyshop.order.web.dto.OrderResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.*;
+import java.util.List;
 
 @RestController
 public class OrderController {
@@ -31,23 +32,26 @@ public class OrderController {
     }
 
     @GetMapping("/api/orders")
-    public List<Map<String, Object>> myOrders(Principal p) {
+    public List<OrderResponseDto> myOrders(Principal p) {
         return service.list(p.getName());
     }
 
     @PostMapping("/api/orders/checkout")
     public ResponseEntity<?> checkout(@RequestBody CheckoutDto dto, Principal pr) {
         if (dto.items() == null || dto.items().isEmpty()) {
-            return ResponseEntity.badRequest().body(Map.of("message", "Empty cart"));
+            return ResponseEntity.badRequest().body(new ApiResponseDto(false, "Empty cart"));
         }
         try {
             return ResponseEntity.ok(service.checkout(dto, pr.getName()));
         } catch (ProductNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "Product not found"));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponseDto(false, "Product not found"));
         } catch (StockNotAvailableException e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", "Stock not available"));
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(new ApiResponseDto(false, "Stock not available"));
         } catch (ServiceUnavailableException e) {
-            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(Map.of("message", "Product service unavailable"));
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(new ApiResponseDto(false, "Product service unavailable"));
         }
     }
 }

--- a/backend/order-service/src/main/java/com/easyshop/order/web/dto/OrderItemDto.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/dto/OrderItemDto.java
@@ -1,0 +1,9 @@
+package com.easyshop.order.web.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * Data transfer object representing an item inside an order.
+ */
+public record OrderItemDto(Long productId, String name, BigDecimal price, Integer quantity) {
+}

--- a/backend/order-service/src/main/java/com/easyshop/order/web/dto/OrderResponseDto.java
+++ b/backend/order-service/src/main/java/com/easyshop/order/web/dto/OrderResponseDto.java
@@ -1,0 +1,10 @@
+package com.easyshop.order.web.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Data transfer object representing a user order.
+ */
+public record OrderResponseDto(Long id, BigDecimal total, String status, List<OrderItemDto> items) {
+}

--- a/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
+++ b/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
@@ -1,7 +1,6 @@
 package com.easyshop.order.web;
 
-import com.easyshop.order.domain.OrderItemRepository;
-import com.easyshop.order.domain.OrderRepository;
+import com.easyshop.order.service.OrderService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -23,10 +22,7 @@ class OrderControllerTest {
     private MockMvc mvc;
 
     @MockBean
-    private OrderRepository orders;
-
-    @MockBean
-    private OrderItemRepository items;
+    private OrderService service;
 
     @Test
     void healthEndpointWorks() throws Exception {


### PR DESCRIPTION
## Summary
- introduce `OrderItemDto` and `OrderResponseDto`
- refactor service and controller to return DTOs instead of generic maps
- update controller test to mock `OrderService`

## Testing
- `mvn -q -f backend/pom.xml -pl order-service test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b550181f40832eaa7b6bf8bb5d706a