### PR TITLE
Add service and controller tests for product and order modules

### DIFF
--- a/backend/order-service/src/test/java/com/easyshop/order/service/OrderServiceTest.java
+++ b/backend/order-service/src/test/java/com/easyshop/order/service/OrderServiceTest.java
@@ -1,0 +1,106 @@
+package com.easyshop.order.service;
+
+import com.easyshop.order.domain.OrderItemRepository;
+import com.easyshop.order.domain.OrderRepository;
+import com.easyshop.order.web.dto.CheckoutDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false",
+        "product.base-url=http://localhost"
+})
+@Transactional
+class OrderServiceTest {
+
+    @Autowired
+    private OrderService service;
+
+    @Autowired
+    private OrderRepository orders;
+
+    @Autowired
+    private OrderItemRepository items;
+
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setupServer() {
+        var builder = org.springframework.web.client.RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        var client = builder.baseUrl("http://localhost").build();
+        ReflectionTestUtils.setField(service, "http", client);
+    }
+
+    @Test
+    void checkoutSuccessfully() {
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost/api/products/1"))
+                .andRespond(MockRestResponseCreators.withSuccess("{\"id\":1,\"name\":\"P1\",\"price\":10}", MediaType.APPLICATION_JSON));
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost/api/admin/products/1/reserve?qty=2"))
+                .andRespond(MockRestResponseCreators.withSuccess());
+
+        CheckoutDto dto = new CheckoutDto(List.of(new CheckoutDto.Item(1L, 2)));
+        Map<String, Object> res = service.checkout(dto, "user@test.com");
+        server.verify();
+
+        assertThat(res.get("total")).isEqualTo(new BigDecimal("20"));
+        assertThat(orders.count()).isEqualTo(1);
+        assertThat(items.count()).isEqualTo(1);
+    }
+
+    @Test
+    void checkoutFailsWhenProductNotFound() {
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost/api/products/1"))
+                .andRespond(MockRestResponseCreators.withStatus(org.springframework.http.HttpStatus.NOT_FOUND));
+
+        CheckoutDto dto = new CheckoutDto(List.of(new CheckoutDto.Item(1L, 1)));
+        assertThatThrownBy(() -> service.checkout(dto, "user@test.com"))
+                .isInstanceOf(OrderService.ProductNotFoundException.class);
+        server.verify();
+        assertThat(orders.count()).isZero();
+    }
+
+    @Test
+    void checkoutFailsWhenStockNotAvailable() {
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost/api/products/1"))
+                .andRespond(MockRestResponseCreators.withSuccess("{\"id\":1,\"name\":\"P1\",\"price\":10}", MediaType.APPLICATION_JSON));
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost/api/admin/products/1/reserve?qty=2"))
+                .andRespond(MockRestResponseCreators.withStatus(org.springframework.http.HttpStatus.CONFLICT));
+
+        CheckoutDto dto = new CheckoutDto(List.of(new CheckoutDto.Item(1L, 2)));
+        assertThatThrownBy(() -> service.checkout(dto, "user@test.com"))
+                .isInstanceOf(OrderService.StockNotAvailableException.class);
+        server.verify();
+        assertThat(orders.count()).isZero();
+    }
+
+    @Test
+    void checkoutFailsWhenServiceUnavailable() {
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost/api/products/1"))
+                .andRespond(MockRestResponseCreators.withServerError());
+
+        CheckoutDto dto = new CheckoutDto(List.of(new CheckoutDto.Item(1L, 1)));
+        assertThatThrownBy(() -> service.checkout(dto, "user@test.com"))
+                .isInstanceOf(OrderService.ServiceUnavailableException.class);
+        server.verify();
+        assertThat(orders.count()).isZero();
+    }
+}
+

--- a/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
+++ b/backend/order-service/src/test/java/com/easyshop/order/web/OrderControllerTest.java
@@ -1,7 +1,9 @@
 package com.easyshop.order.web;
 
-import com.easyshop.order.domain.OrderItemRepository;
-import com.easyshop.order.domain.OrderRepository;
+import com.easyshop.order.service.OrderService;
+import com.easyshop.order.service.OrderService.ProductNotFoundException;
+import com.easyshop.order.service.OrderService.ServiceUnavailableException;
+import com.easyshop.order.service.OrderService.StockNotAvailableException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,7 +12,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,10 +32,7 @@ class OrderControllerTest {
     private MockMvc mvc;
 
     @MockBean
-    private OrderRepository orders;
-
-    @MockBean
-    private OrderItemRepository items;
+    private OrderService service;
 
     @Test
     void healthEndpointWorks() throws Exception {
@@ -34,4 +40,69 @@ class OrderControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok").value(true));
     }
+
+    @Test
+    void checkoutSuccessfully() throws Exception {
+        when(service.checkout(any(), anyString())).thenReturn(
+                Map.of("id", 1, "total", 20, "status", "CREATED", "items", List.of()));
+
+        mvc.perform(post("/api/orders/checkout")
+                        .principal(() -> "user@test.com")
+                        .contentType("application/json")
+                        .content("{\"items\":[{\"productId\":1,\"quantity\":2}]}")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1));
+    }
+
+    @Test
+    void checkoutEmptyCartReturnsBadRequest() throws Exception {
+        mvc.perform(post("/api/orders/checkout")
+                        .principal(() -> "user@test.com")
+                        .contentType("application/json")
+                        .content("{\"items\":[]}")
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Empty cart"));
+    }
+
+    @Test
+    void checkoutProductNotFound() throws Exception {
+        when(service.checkout(any(), anyString())).thenThrow(new ProductNotFoundException());
+
+        mvc.perform(post("/api/orders/checkout")
+                        .principal(() -> "user@test.com")
+                        .contentType("application/json")
+                        .content("{\"items\":[{\"productId\":1,\"quantity\":1}]}")
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Product not found"));
+    }
+
+    @Test
+    void checkoutStockNotAvailable() throws Exception {
+        when(service.checkout(any(), anyString())).thenThrow(new StockNotAvailableException());
+
+        mvc.perform(post("/api/orders/checkout")
+                        .principal(() -> "user@test.com")
+                        .contentType("application/json")
+                        .content("{\"items\":[{\"productId\":1,\"quantity\":1}]}")
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Stock not available"));
+    }
+
+    @Test
+    void checkoutServiceUnavailable() throws Exception {
+        when(service.checkout(any(), anyString())).thenThrow(new ServiceUnavailableException());
+
+        mvc.perform(post("/api/orders/checkout")
+                        .principal(() -> "user@test.com")
+                        .contentType("application/json")
+                        .content("{\"items\":[{\"productId\":1,\"quantity\":1}]}")
+                )
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.message").value("Product service unavailable"));
+    }
 }
+

--- a/backend/product-service/src/test/java/com/easyshop/product/service/ProductServiceTest.java
+++ b/backend/product-service/src/test/java/com/easyshop/product/service/ProductServiceTest.java
@@ -1,0 +1,62 @@
+package com.easyshop.product.service;
+
+import com.easyshop.product.domain.Product;
+import com.easyshop.product.domain.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
+})
+@Transactional
+class ProductServiceTest {
+
+    @Autowired
+    private ProductService service;
+
+    @Autowired
+    private ProductRepository repo;
+
+    @Test
+    void reserveProductSuccessfully() {
+        Product p = repo.save(Product.builder()
+                .name("Test")
+                .description("desc")
+                .price(BigDecimal.TEN)
+                .stock(5)
+                .build());
+
+        var result = service.reserve(p.getId(), 3);
+        assertThat(result).isEqualTo(ProductService.ReserveResult.OK);
+        assertThat(repo.findById(p.getId()).orElseThrow().getStock()).isEqualTo(2);
+    }
+
+    @Test
+    void reserveFailsWhenNotEnoughStock() {
+        Product p = repo.save(Product.builder()
+                .name("Test")
+                .description("desc")
+                .price(BigDecimal.TEN)
+                .stock(2)
+                .build());
+
+        var result = service.reserve(p.getId(), 3);
+        assertThat(result).isEqualTo(ProductService.ReserveResult.NOT_ENOUGH_STOCK);
+        assertThat(repo.findById(p.getId()).orElseThrow().getStock()).isEqualTo(2);
+    }
+
+    @Test
+    void reserveFailsWhenProductNotFound() {
+        var result = service.reserve(999L, 1);
+        assertThat(result).isEqualTo(ProductService.ReserveResult.NOT_FOUND);
+    }
+}
+

--- a/backend/product-service/src/test/java/com/easyshop/product/web/ProductControllerTest.java
+++ b/backend/product-service/src/test/java/com/easyshop/product/web/ProductControllerTest.java
@@ -1,6 +1,6 @@
 package com.easyshop.product.web;
 
-import com.easyshop.product.domain.ProductRepository;
+import com.easyshop.product.service.ProductService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -8,7 +8,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,12 +22,39 @@ class ProductControllerTest {
     private MockMvc mvc;
 
     @MockBean
-    private ProductRepository repo;
+    private ProductService service;
 
     @Test
     void healthEndpointWorks() throws Exception {
         mvc.perform(get("/healthz"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok").value(true));
+    }
+
+    @Test
+    void reserveProductSuccessfully() throws Exception {
+        when(service.reserve(1L, 2)).thenReturn(ProductService.ReserveResult.OK);
+
+        mvc.perform(post("/api/admin/products/1/reserve").param("qty", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
+
+    @Test
+    void reserveProductNotFound() throws Exception {
+        when(service.reserve(1L, 2)).thenReturn(ProductService.ReserveResult.NOT_FOUND);
+
+        mvc.perform(post("/api/admin/products/1/reserve").param("qty", "2"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void reserveProductNotEnoughStock() throws Exception {
+        when(service.reserve(1L, 2)).thenReturn(ProductService.ReserveResult.NOT_ENOUGH_STOCK);
+
+        mvc.perform(post("/api/admin/products/1/reserve").param("qty", "2"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.ok").value(false))
+                .andExpect(jsonPath("$.message").value("Not enough stock"));
     }
 }


### PR DESCRIPTION
## Summary
- add Spring Boot tests for ProductService.reserve success and failure cases
- cover product reservation controller endpoint for OK, conflict, and not-found
- add comprehensive OrderService.checkout tests using MockRestServiceServer
- exercise order checkout controller for success, empty cart, and error scenarios

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b5501cafac832e8730c00095fcc35e