### PR TITLE
chore: introduce reusable build base for services

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,7 +1,5 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
 RUN mvn -q -DskipTests -f api-gateway/pom.xml dependency:go-offline
 COPY api-gateway/src ./api-gateway/src

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -1,12 +1,7 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
 
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
 COPY auth-service/pom.xml ./auth-service/pom.xml
-RUN mvn -q -DskipTests -f common-security/pom.xml install
 RUN mvn -q -DskipTests -f auth-service/pom.xml dependency:go-offline
 
 COPY auth-service/src ./auth-service/src

--- a/backend/build-base.Dockerfile
+++ b/backend/build-base.Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3.9-eclipse-temurin-21
+
+WORKDIR /app
+
+# Copy project root POM and common-security module
+COPY pom.xml ./pom.xml
+COPY common-security/pom.xml ./common-security/pom.xml
+COPY common-security/src ./common-security/src
+
+# Pre-build common-security with cached dependencies
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -q -N -DskipTests install && \
+    mvn -q -DskipTests -pl common-security install
+

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -1,12 +1,7 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
 
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
 COPY order-service/pom.xml ./order-service/pom.xml
-RUN mvn -q -DskipTests -f common-security/pom.xml install
 RUN mvn -q -DskipTests -f order-service/pom.xml dependency:go-offline
 
 COPY order-service/src ./order-service/src

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -1,12 +1,7 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
 
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
 COPY product-service/pom.xml ./product-service/pom.xml
-RUN mvn -q -DskipTests -f common-security/pom.xml install
 RUN mvn -q -DskipTests -f product-service/pom.xml dependency:go-offline
 
 COPY product-service/src ./product-service/src


### PR DESCRIPTION
## Summary
- add backend/build-base.Dockerfile to prebuild common-security module and cache Maven deps
- refactor service Dockerfiles to use easyshop-build-base and remove duplicated common-security steps

## Testing
- `apt-get update`
- `DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io`
- `docker build -t easyshop-build-base:latest -f backend/build-base.Dockerfile backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b5590e17f4832e9421a26389ea0bad