### PR TITLE
Simplify service Dockerfiles with aggregated Maven build

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,11 +1,9 @@
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY api-gateway/pom.xml ./api-gateway/pom.xml
-RUN mvn -q -DskipTests -f api-gateway/pom.xml dependency:go-offline
-COPY api-gateway/src ./api-gateway/src
-RUN mvn -q -DskipTests -f api-gateway/pom.xml package
+
+COPY . .
+RUN mvn -B -q -DskipTests -pl api-gateway -am package
+
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/api-gateway/target/*.jar app.jar

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -1,16 +1,8 @@
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
-COPY auth-service/pom.xml ./auth-service/pom.xml
-RUN mvn -q -DskipTests -f common-security/pom.xml install
-RUN mvn -q -DskipTests -f auth-service/pom.xml dependency:go-offline
-
-COPY auth-service/src ./auth-service/src
-RUN mvn -q -DskipTests -f auth-service/pom.xml package
+COPY . .
+RUN mvn -B -q -DskipTests -pl auth-service -am package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -1,16 +1,8 @@
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
-COPY order-service/pom.xml ./order-service/pom.xml
-RUN mvn -q -DskipTests -f common-security/pom.xml install
-RUN mvn -q -DskipTests -f order-service/pom.xml dependency:go-offline
-
-COPY order-service/src ./order-service/src
-RUN mvn -q -DskipTests -f order-service/pom.xml package
+COPY . .
+RUN mvn -B -q -DskipTests -pl order-service -am package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -1,16 +1,8 @@
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 
-COPY pom.xml ./pom.xml
-RUN mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
-COPY product-service/pom.xml ./product-service/pom.xml
-RUN mvn -q -DskipTests -f common-security/pom.xml install
-RUN mvn -q -DskipTests -f product-service/pom.xml dependency:go-offline
-
-COPY product-service/src ./product-service/src
-RUN mvn -q -DskipTests -f product-service/pom.xml package
+COPY . .
+RUN mvn -B -q -DskipTests -pl product-service -am package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app


### PR DESCRIPTION
## Summary
- Simplify backend service Dockerfiles to copy the entire backend directory
- Build each service with `mvn -B -q -DskipTests -pl <module> -am package` to resolve dependencies like `common-security`
- Drop `dependency:go-offline` steps in favor of the aggregated build

## Testing
- `mvn -B -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b559102754832e810e491c49deff13