### PR TITLE
Configure Maven repository deployment

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -21,5 +21,15 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
-      - name: Run tests
-        run: mvn -B -f backend/pom.xml test
+      - name: Deploy common-security
+        run: mvn -B -f backend/common-security/pom.xml deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test auth service
+        run: mvn -B -f backend/auth-service/pom.xml test
+      - name: Test product service
+        run: mvn -B -f backend/product-service/pom.xml test
+      - name: Test order service
+        run: mvn -B -f backend/order-service/pom.xml test
+      - name: Test API gateway
+        run: mvn -B -f backend/api-gateway/pom.xml test

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -5,31 +5,51 @@
 
   <localRepository>C:/Users/kalmykov/.m2_easyshop/repository</localRepository>
 
-  <mirrors/>
+    <mirrors/>
 
-  <profiles>
-    <profile>
-      <id>use-central-only</id>
-      <repositories>
-        <repository>
-          <id>central</id>
-          <url>https://repo1.maven.org/maven2</url>
-          <releases><enabled>true</enabled></releases>
-          <snapshots><enabled>false</enabled></snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>central</id>
-          <url>https://repo1.maven.org/maven2</url>
-          <releases><enabled>true</enabled></releases>
-          <snapshots><enabled>false</enabled></snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
+    <servers>
+      <server>
+        <id>github</id>
+        <username>${env.GITHUB_ACTOR}</username>
+        <password>${env.GITHUB_TOKEN}</password>
+      </server>
+    </servers>
 
-  <activeProfiles>
-    <activeProfile>use-central-only</activeProfile>
-  </activeProfiles>
-</settings>
+    <profiles>
+      <profile>
+        <id>easyshop-repos</id>
+        <repositories>
+          <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+          </repository>
+          <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+          </repository>
+        </repositories>
+        <pluginRepositories>
+          <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+          </pluginRepository>
+          <pluginRepository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+          </pluginRepository>
+        </pluginRepositories>
+      </profile>
+    </profiles>
+
+    <activeProfiles>
+      <activeProfile>easyshop-repos</activeProfile>
+    </activeProfiles>
+  </settings>

--- a/backend/api-gateway/pom.xml
+++ b/backend/api-gateway/pom.xml
@@ -13,6 +13,19 @@
     <artifactId>api-gateway</artifactId>
     <name>api-gateway</name>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/auth-service/pom.xml
+++ b/backend/auth-service/pom.xml
@@ -13,6 +13,19 @@
     <artifactId>auth-service</artifactId>
     <name>auth-service</name>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/common-security/pom.xml
+++ b/backend/common-security/pom.xml
@@ -13,6 +13,19 @@
     <artifactId>common-security</artifactId>
     <name>common-security</name>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/order-service/pom.xml
+++ b/backend/order-service/pom.xml
@@ -13,6 +13,19 @@
     <artifactId>order-service</artifactId>
     <name>order-service</name>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Spring -->
         <dependency>

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -13,6 +13,19 @@
     <artifactId>product-service</artifactId>
     <name>product-service</name>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- configure common-security to publish to GitHub Packages via distribution management
- add GitHub Packages server and repository to Maven settings and service POMs
- update backend CI workflow to deploy common-security and test each service individually

## Testing
- `mvn -f backend/common-security/pom.xml install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies from/to central - Network is unreachable)*
- `mvn -f backend/auth-service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies from/to GitHub Packages - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5591109dc832e9f76af51bd91e20b