### PR TITLE
Streamline service Dockerfiles with build base image

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,7 +1,5 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
-COPY pom.xml ./pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -N -DskipTests install
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f api-gateway/pom.xml dependency:go-offline
 COPY api-gateway/src ./api-gateway/src

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -1,11 +1,6 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
-COPY pom.xml ./pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
 COPY auth-service/pom.xml ./auth-service/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f common-security/pom.xml install
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f auth-service/pom.xml dependency:go-offline
 COPY auth-service/src ./auth-service/src
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f auth-service/pom.xml package

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -1,11 +1,6 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
-COPY pom.xml ./pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
 COPY order-service/pom.xml ./order-service/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f common-security/pom.xml install
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f order-service/pom.xml dependency:go-offline
 COPY order-service/src ./order-service/src
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f order-service/pom.xml package

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -1,11 +1,6 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM easyshop-build-base:latest AS build
 WORKDIR /app
-COPY pom.xml ./pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -N -DskipTests install
-COPY common-security/pom.xml ./common-security/pom.xml
-COPY common-security/src ./common-security/src
 COPY product-service/pom.xml ./product-service/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f common-security/pom.xml install
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f product-service/pom.xml dependency:go-offline
 COPY product-service/src ./product-service/src
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f product-service/pom.xml package


### PR DESCRIPTION
## Summary
- Use `easyshop-build-base` in all backend service Dockerfiles
- Drop redundant `pom.xml` and `common-security` copy/install steps
- Keep Maven cache mounts for dependency download and packaging

## Testing
- `mvn -q test -f backend/pom.xml` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b560661ff8832ea4829f85e0b0050a