### PR TITLE
Add base Maven build Dockerfile

### DIFF
--- a/backend/build-base.Dockerfile
+++ b/backend/build-base.Dockerfile
@@ -1,0 +1,6 @@
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+COPY pom.xml ./pom.xml
+COPY common-security/ ./common-security/
+
+RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl common-security install


### PR DESCRIPTION
## Summary
- add backend/build-base.Dockerfile for Maven build cache image

## Testing
- `DOCKER_BUILDKIT=1 docker build -f backend/build-base.Dockerfile -t easyshop-build-base:latest backend` *(fails: BuildKit component missing)*
- `docker push easyshop-build-base:latest` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b560697048832eb63c9579dfee183c