### PR TITLE
Include common-web module in backend base Docker image

### DIFF
--- a/backend/build-base.Dockerfile
+++ b/backend/build-base.Dockerfile
@@ -2,5 +2,7 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 
 COPY pom.xml ./pom.xml
 COPY common-security/ ./common-security/
+COPY common-web/ ./common-web/
 
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl common-security install
+# Install shared modules with Maven, using a cached local repository
+RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl common-security,common-web install


### PR DESCRIPTION
## Summary
- copy common-web module into base image build context
- install common-security and common-web in a single Maven command with cached repository

## Testing
- `mvn -q -f backend/pom.xml -DskipTests -pl common-security,common-web -Djava.net.preferIPv4Stack=true install` *(fails: Non-resolvable import POM: Could not transfer artifact: Network is unreachable)*
- `docker build -t easyshop-backend-base:latest -f backend/build-base.Dockerfile backend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b5702e9650832e93810225fad2a3de