### PR TITLE
Version build base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ DOCKER_BUILDKIT=1 docker compose -f infra/dev/docker-compose.dev.yml up --build
 ```
 
 > Docker builds require BuildKit. Ensure `DOCKER_BUILDKIT=1` is set when building images.
+
+## Build image versioning
+
+The shared build image `easyshop-build-base` is tagged with a semantic
+version. Build and tag the image explicitly, for example:
+
+```
+docker build -t easyshop-build-base:1.0.0 -f backend/build-base.Dockerfile backend
+```
+
+Service Dockerfiles pin to a specific version tag. When the base image is
+updated, create a new tag (e.g., `1.0.1`, `1.1.0`, etc.) and update the
+service Dockerfiles accordingly instead of reusing `latest`.

--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM easyshop-build-base:latest AS build
+FROM easyshop-build-base:1.0.0 AS build
 WORKDIR /app
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -f api-gateway/pom.xml dependency:go-offline

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM easyshop-build-base:latest AS build
+FROM easyshop-build-base:1.0.0 AS build
 WORKDIR /app
 
 COPY auth-service/pom.xml ./auth-service/pom.xml

--- a/backend/build-base.Dockerfile
+++ b/backend/build-base.Dockerfile
@@ -1,5 +1,7 @@
 FROM maven:3.9-eclipse-temurin-21 AS build
 
+LABEL org.opencontainers.image.version="1.0.0"
+
 COPY pom.xml ./pom.xml
 COPY common-security/ ./common-security/
 

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM easyshop-build-base:latest AS build
+FROM easyshop-build-base:1.0.0 AS build
 WORKDIR /app
 
 COPY order-service/pom.xml ./order-service/pom.xml

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM easyshop-build-base:latest AS build
+FROM easyshop-build-base:1.0.0 AS build
 WORKDIR /app
 
 COPY product-service/pom.xml ./product-service/pom.xml


### PR DESCRIPTION
## Summary
- add version label to the build base image
- pin backend service Dockerfiles to easyshop-build-base:1.0.0
- document Docker image versioning so tags are incremented instead of reusing `latest`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact from https://repo.maven.apache.org/maven2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5702dc134832ea4c57f4a465d1191