### PR TITLE
Include common-web module in build base Dockerfile

### DIFF
--- a/backend/build-base.Dockerfile
+++ b/backend/build-base.Dockerfile
@@ -4,4 +4,5 @@ ARG GITHUB_TOKEN
 COPY settings.xml /usr/share/maven/ref/settings.xml
 COPY pom.xml ./pom.xml
 COPY common-security/ ./common-security/
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -pl common-security install
+COPY common-web/ ./common-web/
+RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -pl common-security,common-web install


### PR DESCRIPTION
## Summary
- copy common-web module into build base image
- install common-security and common-web modules during image build

## Testing
- `docker build -t easyshop-build-base -f backend/build-base.Dockerfile backend` *(fails: Cannot connect to the Docker daemon)*
- `docker push easyshop-build-base` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b578339490832e939eb85d4a56446c