### PR TITLE
chore: pass GitHub creds during prod builds

### DIFF
--- a/infra/prod/docker-compose.prod.yml
+++ b/infra/prod/docker-compose.prod.yml
@@ -1,11 +1,15 @@
 # Compose file for production. Uses per-module Dockerfiles but builds with backend root as context.
 # IMPORTANT: ensure your .env.prod has DB_URL=jdbc:postgresql://db:5432/easyshop
+# Ensure GITHUB_ACTOR and GITHUB_TOKEN are defined before running `docker compose build`
 
 services:
   frontend:
     build:
       context: ../../frontend
       dockerfile: Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "80:80"
     depends_on:
@@ -16,6 +20,9 @@ services:
     build:
       context: ../../backend          # root so parent pom.xml is available
       dockerfile: api-gateway/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8080:8080"
     environment:
@@ -32,6 +39,9 @@ services:
     build:
       context: ../../backend
       dockerfile: auth-service/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8081:8080"
     environment:
@@ -47,6 +57,9 @@ services:
     build:
       context: ../../backend
       dockerfile: order-service/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8082:8080"
     environment:
@@ -62,6 +75,9 @@ services:
     build:
       context: ../../backend
       dockerfile: product-service/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8083:8080"
     environment:


### PR DESCRIPTION
## Summary
- pass `GITHUB_ACTOR` and `GITHUB_TOKEN` as build args for each service in production compose
- note requirement to define these variables before running `docker compose build`

## Testing
- `docker-compose -f infra/prod/docker-compose.prod.yml config`

------
https://chatgpt.com/codex/tasks/task_e_68b57b56235c832e978046c947e7f289