### PR TITLE
Add workflow to build and push backend images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,50 @@
+name: Build Backend Images
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/build-images.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/build-images.yml'
+
+env:
+  IMAGE_VERSION: 1.0.0
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: Build base image
+        run: docker build -f backend/build-base.Dockerfile -t easyshop-build-base:${IMAGE_VERSION} backend
+      - name: Push base image
+        run: docker push easyshop-build-base:${IMAGE_VERSION}
+
+  build-services:
+    needs: build-base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: Build and push auth service image
+        run: |
+          docker build -t auth-service:${IMAGE_VERSION} backend/auth-service
+          docker push auth-service:${IMAGE_VERSION}
+      - name: Build and push product service image
+        run: |
+          docker build -t product-service:${IMAGE_VERSION} backend/product-service
+          docker push product-service:${IMAGE_VERSION}
+      - name: Build and push order service image
+        run: |
+          docker build -t order-service:${IMAGE_VERSION} backend/order-service
+          docker push order-service:${IMAGE_VERSION}
+      - name: Build and push API gateway image
+        run: |
+          docker build -t api-gateway:${IMAGE_VERSION} backend/api-gateway
+          docker push api-gateway:${IMAGE_VERSION}


### PR DESCRIPTION
## Summary
- add CI workflow to build base image and push service images sequentially

## Testing
- `docker build -f backend/build-base.Dockerfile -t easyshop-build-base:1.0.0 backend` (fails: command not found)
- `docker push easyshop-build-base:1.0.0` (fails: command not found)
- `mvn -B -f backend/pom.xml test` (fails: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68b57b56ce70832ea6fae6e285dceb4d