### PR TITLE
chore: enable buildkit in ci

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -10,6 +10,9 @@ on:
       - 'backend/**'
       - '.github/workflows/backend-tests.yml'
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure BuildKit is enabled during CI builds by setting `DOCKER_BUILDKIT=1`

## Testing
- `yamllint .github/workflows/backend-tests.yml`
- `DOCKER_BUILDKIT=1 docker compose -f infra/prod/docker-compose.prod.yml build frontend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68b57b581158832ebddd550d6b1d7ee3