### PR TITLE
feat: use offline Maven builds

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -3,9 +3,8 @@ ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f api-gateway/pom.xml dependency:go-offline
 COPY api-gateway/src ./api-gateway/src
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f api-gateway/pom.xml package
+RUN mvn -o -q -DskipTests -f api-gateway/pom.xml package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/api-gateway/target/*.jar app.jar

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -3,9 +3,8 @@ ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
 COPY auth-service/pom.xml ./auth-service/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f auth-service/pom.xml dependency:go-offline
 COPY auth-service/src ./auth-service/src
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f auth-service/pom.xml package
+RUN mvn -o -q -DskipTests -f auth-service/pom.xml package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/auth-service/target/*.jar app.jar

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -3,9 +3,8 @@ ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
 COPY order-service/pom.xml ./order-service/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f order-service/pom.xml dependency:go-offline
 COPY order-service/src ./order-service/src
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f order-service/pom.xml package
+RUN mvn -o -q -DskipTests -f order-service/pom.xml package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/order-service/target/*.jar app.jar

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -3,9 +3,8 @@ ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
 COPY product-service/pom.xml ./product-service/pom.xml
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f product-service/pom.xml dependency:go-offline
 COPY product-service/src ./product-service/src
-RUN --mount=type=cache,target=/root/.m2 mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests -f product-service/pom.xml package
+RUN mvn -o -q -DskipTests -f product-service/pom.xml package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/product-service/target/*.jar app.jar


### PR DESCRIPTION
## Summary
- build backend services with Maven's offline mode
- remove dependency:go-offline step from service Dockerfiles

## Testing
- `docker build -t product-service-test -f backend/product-service/Dockerfile .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b581412618832e8933558ee875f7e4