### PR TITLE
feat: make maven repo configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+MAVEN_REPO_URL=https://maven.pkg.github.com/EasyShopOrg/EasyShop
 PUBLIC_DOMAIN=
 ACCOUNT_DOMAIN=
 ADMIN_DOMAIN=

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ DOCKER_BUILDKIT=1 docker compose -f infra/dev/docker-compose.dev.yml up --build
 
 > Docker builds require BuildKit. Ensure `DOCKER_BUILDKIT=1` is set when building images.
 
+## Maven repository
+
+Backend modules resolve internal artifacts from the Maven repository URL
+specified by `MAVEN_REPO_URL` in your `.env`. To point the build to a new
+repository, update this variable.
+
 ## Build image versioning
 
 The shared build image `easyshop-build-base` is tagged with a semantic

--- a/backend/api-gateway/pom.xml
+++ b/backend/api-gateway/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <url>${repo.url}</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/auth-service/pom.xml
+++ b/backend/auth-service/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <url>${repo.url}</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/common-security/pom.xml
+++ b/backend/common-security/pom.xml
@@ -17,12 +17,12 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <url>${repo.url}</url>
         </repository>
         <snapshotRepository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <url>${repo.url}</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/backend/order-service/pom.xml
+++ b/backend/order-service/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <url>${repo.url}</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -23,6 +23,7 @@
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
+        <repo.url>${env.MAVEN_REPO_URL}</repo.url>
     </properties>
 
     <!-- Spring Boot BOM drives versions of starters and many libs -->

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/EasyShopOrg/EasyShop</url>
+            <url>${repo.url}</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
## Summary
- make Maven repository URL configurable via `repo.url` property in backend POM
- reference `repo.url` in service POMs instead of hard-coded GitHub Packages URL
- document `MAVEN_REPO_URL` in `.env` and README

## Testing
- `MAVEN_REPO_URL=https://repo1.maven.org/maven2 mvn -q -f backend/pom.xml test` *(failed: Non-resolvable import POM: could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b58cbbbd7c832ebdd7ac958051464d