### PR TITLE
chore: remove GITHUB_ACTOR/TOKEN args from service Dockerfiles

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,6 +1,4 @@
 FROM easyshop-build-base:1.0.0 AS build
-ARG GITHUB_ACTOR
-ARG GITHUB_TOKEN
 WORKDIR /app
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
 COPY api-gateway/src ./api-gateway/src

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -1,6 +1,4 @@
 FROM easyshop-build-base:1.0.0 AS build
-ARG GITHUB_ACTOR
-ARG GITHUB_TOKEN
 WORKDIR /app
 COPY auth-service/pom.xml ./auth-service/pom.xml
 COPY auth-service/src ./auth-service/src

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -1,6 +1,4 @@
 FROM easyshop-build-base:1.0.0 AS build
-ARG GITHUB_ACTOR
-ARG GITHUB_TOKEN
 WORKDIR /app
 COPY order-service/pom.xml ./order-service/pom.xml
 COPY order-service/src ./order-service/src

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -1,6 +1,4 @@
 FROM easyshop-build-base:1.0.0 AS build
-ARG GITHUB_ACTOR
-ARG GITHUB_TOKEN
 WORKDIR /app
 COPY product-service/pom.xml ./product-service/pom.xml
 COPY product-service/src ./product-service/src


### PR DESCRIPTION
## Summary
- remove build args for GITHUB_ACTOR and GITHUB_TOKEN from api-gateway, auth-service, order-service and product-service Dockerfiles

## Testing
- `podman build --network none -f backend/api-gateway/Dockerfile backend` *(fails: invalid internal status, libpod/tmp/pause.pid: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b58cbc64ac832ea32e28ef748de10e