### PR TITLE
chore: restrict GitHub credentials to base build

### DIFF
--- a/infra/prod/docker-compose.prod.yml
+++ b/infra/prod/docker-compose.prod.yml
@@ -1,15 +1,24 @@
-# Compose file for production. Uses per-module Dockerfiles but builds with backend root as context.
+---
+# Compose file for production. Uses per-module Dockerfiles
+# but builds with backend root as context.
 # IMPORTANT: ensure your .env.prod has DB_URL=jdbc:postgresql://db:5432/easyshop
-# Ensure GITHUB_ACTOR and GITHUB_TOKEN are defined before running `docker compose build`
+# Ensure GITHUB_ACTOR and GITHUB_TOKEN are defined before running
+# `docker compose build build-base`
 
 services:
+  build-base:
+    image: easyshop-build-base:1.0.0
+    build:
+      context: ../../backend
+      dockerfile: build-base.Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
+
   frontend:
     build:
       context: ../../frontend
       dockerfile: Dockerfile
-      args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "80:80"
     depends_on:
@@ -20,9 +29,6 @@ services:
     build:
       context: ../../backend          # root so parent pom.xml is available
       dockerfile: api-gateway/Dockerfile
-      args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8080:8080"
     environment:
@@ -39,9 +45,6 @@ services:
     build:
       context: ../../backend
       dockerfile: auth-service/Dockerfile
-      args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8081:8080"
     environment:
@@ -57,9 +60,6 @@ services:
     build:
       context: ../../backend
       dockerfile: order-service/Dockerfile
-      args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8082:8080"
     environment:
@@ -75,9 +75,6 @@ services:
     build:
       context: ../../backend
       dockerfile: product-service/Dockerfile
-      args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8083:8080"
     environment:


### PR DESCRIPTION
## Summary
- build base backend image with GitHub credentials via dedicated service
- remove GitHub credentials from individual service Docker builds

## Testing
- `yamllint infra/prod/docker-compose.prod.yml`
- `docker compose -f infra/prod/docker-compose.prod.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59762c16c832ea88fceb9c799d1b7