### PR TITLE
feat: include all services in base build

### DIFF
--- a/backend/build-base.Dockerfile
+++ b/backend/build-base.Dockerfile
@@ -5,8 +5,12 @@ COPY settings.xml /usr/share/maven/ref/settings.xml
 COPY pom.xml ./pom.xml
 COPY common-security/ ./common-security/
 COPY common-web/ ./common-web/
+COPY auth-service/ ./auth-service/
+COPY product-service/ ./product-service/
+COPY order-service/ ./order-service/
+COPY api-gateway/ ./api-gateway/
 RUN --mount=type=cache,target=/root/.m2 \
     mvn --settings /usr/share/maven/ref/settings.xml -q -DskipTests \
-        -pl common-security,common-web dependency:go-offline install && \
+        dependency:go-offline install && \
     cp -r /root/.m2 /m2
 ENV MAVEN_OPTS="-Dmaven.repo.local=/m2"


### PR DESCRIPTION
## Summary
- copy backend service modules into base Maven image
- fetch dependencies for all modules during Maven offline build

## Testing
- `mvn --settings settings.xml -q -DskipTests dependency:go-offline` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3 from/to central)*
- `docker-compose --env-file infra/prod/.env.prod -f infra/prod/docker-compose.prod.yml build build-base` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))*


------
https://chatgpt.com/codex/tasks/task_e_68b5a2785b4c832eacc47d38088b0742