### PR TITLE
chore: update prod compose build args

### DIFF
--- a/infra/prod/docker-compose.prod.yml
+++ b/infra/prod/docker-compose.prod.yml
@@ -2,19 +2,9 @@
 # Compose file for production. Uses per-module Dockerfiles
 # but builds with backend root as context.
 # IMPORTANT: ensure your .env.prod has DB_URL=jdbc:postgresql://db:5432/easyshop
-# Ensure GITHUB_ACTOR and GITHUB_TOKEN are defined before running
-# `docker compose build build-base`
+# Ensure GITHUB_ACTOR and GITHUB_TOKEN are defined before building
 
 services:
-  build-base:
-    image: easyshop-build-base:1.0.0
-    build:
-      context: ../../backend
-      dockerfile: build-base.Dockerfile
-      args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
-
   frontend:
     build:
       context: ../../frontend
@@ -29,6 +19,9 @@ services:
     build:
       context: ../../backend          # root so parent pom.xml is available
       dockerfile: api-gateway/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8080:8080"
     environment:
@@ -45,6 +38,9 @@ services:
     build:
       context: ../../backend
       dockerfile: auth-service/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8081:8080"
     environment:
@@ -60,6 +56,9 @@ services:
     build:
       context: ../../backend
       dockerfile: order-service/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8082:8080"
     environment:
@@ -75,6 +74,9 @@ services:
     build:
       context: ../../backend
       dockerfile: product-service/Dockerfile
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     ports:
       - "8083:8080"
     environment:


### PR DESCRIPTION
## Summary
- remove build-base service from production compose
- forward GitHub credentials when building backend services

## Testing
- `docker compose -f infra/prod/docker-compose.prod.yml config` *(fails: command not found)*
- `python - <<'PY'\nimport yaml,sys\nyaml.safe_load(open('infra/prod/docker-compose.prod.yml'))\nprint('YAML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68b5a4fb3978832e9a9cbf82f50cd34e