### PR TITLE
Copy all modules in backend Docker builds

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -6,6 +6,9 @@ COPY settings.xml /usr/share/maven/ref/settings.xml
 COPY pom.xml ./
 COPY common-security ./common-security
 COPY common-web ./common-web
+COPY auth-service ./auth-service
+COPY product-service ./product-service
+COPY order-service ./order-service
 COPY api-gateway ./api-gateway
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl api-gateway -am package
 FROM eclipse-temurin:21-jre

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -7,6 +7,9 @@ COPY pom.xml ./
 COPY common-security ./common-security
 COPY common-web ./common-web
 COPY auth-service ./auth-service
+COPY product-service ./product-service
+COPY order-service ./order-service
+COPY api-gateway ./api-gateway
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl auth-service -am package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -6,7 +6,10 @@ COPY settings.xml /usr/share/maven/ref/settings.xml
 COPY pom.xml ./
 COPY common-security ./common-security
 COPY common-web ./common-web
+COPY auth-service ./auth-service
+COPY product-service ./product-service
 COPY order-service ./order-service
+COPY api-gateway ./api-gateway
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl order-service -am package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -6,7 +6,10 @@ COPY settings.xml /usr/share/maven/ref/settings.xml
 COPY pom.xml ./
 COPY common-security ./common-security
 COPY common-web ./common-web
+COPY auth-service ./auth-service
 COPY product-service ./product-service
+COPY order-service ./order-service
+COPY api-gateway ./api-gateway
 RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl product-service -am package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app


### PR DESCRIPTION
## Summary
- include all service modules in backend Docker build contexts

## Testing
- `docker compose --env-file infra/prod/.env.prod -f infra/prod/docker-compose.prod.yml build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b61815f8832e82f94007bd4984fc