### PR TITLE
Add spring context and SLF4J dependencies to common-web module

### DIFF
--- a/backend/common-web/pom.xml
+++ b/backend/common-web/pom.xml
@@ -30,5 +30,13 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- include spring-context dependency for shared web utilities
- add slf4j-api to support logging abstractions

## Testing
- `docker-compose --env-file infra/prod/.env.prod -f infra/prod/docker-compose.prod.yml build 2>&1 | tail -n 20` *(fails: DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9c7f34c832eb637c9fd033e5100