### PR TITLE
Streamline service Dockerfiles for targeted builds

### DIFF
--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -2,15 +2,11 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
+COPY .mvn/ .mvn
+COPY pom.xml .
 COPY settings.xml /usr/share/maven/ref/settings.xml
-COPY pom.xml ./
-COPY common-security ./common-security
-COPY common-web ./common-web
 COPY auth-service ./auth-service
-COPY product-service ./product-service
-COPY order-service ./order-service
-COPY api-gateway ./api-gateway
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl auth-service -am package
+RUN --mount=type=cache,target=/root/.m2 mvn -q -pl auth-service -am package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/auth-service/target/*.jar app.jar

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -2,15 +2,11 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
+COPY .mvn/ .mvn
+COPY pom.xml .
 COPY settings.xml /usr/share/maven/ref/settings.xml
-COPY pom.xml ./
-COPY common-security ./common-security
-COPY common-web ./common-web
-COPY auth-service ./auth-service
-COPY product-service ./product-service
 COPY order-service ./order-service
-COPY api-gateway ./api-gateway
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl order-service -am package
+RUN --mount=type=cache,target=/root/.m2 mvn -q -pl order-service -am package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/order-service/target/*.jar app.jar

--- a/backend/product-service/Dockerfile
+++ b/backend/product-service/Dockerfile
@@ -2,15 +2,11 @@ FROM maven:3.9-eclipse-temurin-21 AS build
 ARG GITHUB_ACTOR
 ARG GITHUB_TOKEN
 WORKDIR /app
+COPY .mvn/ .mvn
+COPY pom.xml .
 COPY settings.xml /usr/share/maven/ref/settings.xml
-COPY pom.xml ./
-COPY common-security ./common-security
-COPY common-web ./common-web
-COPY auth-service ./auth-service
 COPY product-service ./product-service
-COPY order-service ./order-service
-COPY api-gateway ./api-gateway
-RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests -pl product-service -am package
+RUN --mount=type=cache,target=/root/.m2 mvn -q -pl product-service -am package
 FROM eclipse-temurin:21-jre
 WORKDIR /opt/app
 COPY --from=build /app/product-service/target/*.jar app.jar


### PR DESCRIPTION
## Summary
- Copy only the service module, Maven files and settings in each service Dockerfile
- Build each Docker image with `mvn -q -pl <service> -am package` to resolve only required modules

## Testing
- `mvn -q -pl auth-service,product-service,order-service -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa9e9318832eb81a65e938eaa645