### PR TITLE
Add per-service publish workflows

### DIFF
--- a/.github/workflows/publish-api-gateway.yml
+++ b/.github/workflows/publish-api-gateway.yml
@@ -1,0 +1,31 @@
+---
+name: Publish API Gateway
+
+'on':
+  push:
+    paths:
+      - 'backend/api-gateway/**'
+      - '.github/workflows/publish-api-gateway.yml'
+  pull_request:
+    paths:
+      - 'backend/api-gateway/**'
+      - '.github/workflows/publish-api-gateway.yml'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Deploy API Gateway
+        run: |
+          mvn -B -f backend/pom.xml \
+            --settings backend/settings.xml \
+            --projects api-gateway deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-auth-service.yml
+++ b/.github/workflows/publish-auth-service.yml
@@ -1,0 +1,31 @@
+---
+name: Publish Auth Service
+
+'on':
+  push:
+    paths:
+      - 'backend/auth-service/**'
+      - '.github/workflows/publish-auth-service.yml'
+  pull_request:
+    paths:
+      - 'backend/auth-service/**'
+      - '.github/workflows/publish-auth-service.yml'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Deploy Auth Service
+        run: |
+          mvn -B -f backend/pom.xml \
+            --settings backend/settings.xml \
+            --projects auth-service deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-order-service.yml
+++ b/.github/workflows/publish-order-service.yml
@@ -1,0 +1,31 @@
+---
+name: Publish Order Service
+
+'on':
+  push:
+    paths:
+      - 'backend/order-service/**'
+      - '.github/workflows/publish-order-service.yml'
+  pull_request:
+    paths:
+      - 'backend/order-service/**'
+      - '.github/workflows/publish-order-service.yml'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Deploy Order Service
+        run: |
+          mvn -B -f backend/pom.xml \
+            --settings backend/settings.xml \
+            --projects order-service deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-product-service.yml
+++ b/.github/workflows/publish-product-service.yml
@@ -1,0 +1,31 @@
+---
+name: Publish Product Service
+
+'on':
+  push:
+    paths:
+      - 'backend/product-service/**'
+      - '.github/workflows/publish-product-service.yml'
+  pull_request:
+    paths:
+      - 'backend/product-service/**'
+      - '.github/workflows/publish-product-service.yml'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Deploy Product Service
+        run: |
+          mvn -B -f backend/pom.xml \
+            --settings backend/settings.xml \
+            --projects product-service deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add Maven publish workflows for auth, product, order, and API gateway services
- restrict each workflow to changes within its service directory
- use `GITHUB_TOKEN` and `--projects` to deploy only the targeted module

## Testing
- `yamllint .github/workflows/publish-auth-service.yml .github/workflows/publish-product-service.yml .github/workflows/publish-order-service.yml .github/workflows/publish-api-gateway.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b5fab781d8832e96d4fdffd073d662