### PR TITLE
Externalize config to env vars and document required environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ Backend modules resolve internal artifacts from the Maven repository URL
 specified by `MAVEN_REPO_URL` in your `.env`. To point the build to a new
 repository, update this variable.
 
+## Environment variables
+
+Backend services read configuration from environment variables. Provide them via
+`.env` files for local runs or CI secrets in automated pipelines:
+
+- `SERVER_PORT` – port the service listens on.
+- `SPRING_DATASOURCE_URL` – JDBC connection string for Postgres.
+- `SPRING_DATASOURCE_USERNAME` – database username.
+- `SPRING_DATASOURCE_PASSWORD` – database password (secret).
+- `JWT_SECRET` – signing key for JWT tokens (secret).
+- `JWT_TTL_MINUTES` – token lifetime in minutes (defaults to `60`).
+- `AUTH_URL` – base URL of the auth service for the API gateway.
+- `PRODUCT_URL` – base URL of the product service for the API gateway.
+- `ORDER_URL` – base URL of the order service for the API gateway.
+- `PRODUCT_BASE_URL` – product service URL used by the order service.
+
 ## Production setup
 
 On the server, copy the example environment file and fill in the values:

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -1,17 +1,17 @@
-server: { port: 8080 }
+server: { port: ${SERVER_PORT:8080} }
 spring:
   application: { name: api-gateway }
   cloud:
     gateway:
       routes:
         - id: auth
-          uri: ${AUTH_URL:http://auth-service:9001}
+          uri: ${AUTH_URL}
           predicates: [ Path=/api/auth/**, /healthz, /readyz ]
         - id: products
-          uri: ${PRODUCT_URL:http://product-service:9002}
+          uri: ${PRODUCT_URL}
           predicates: [ Path=/api/products/** ]
         - id: orders
-          uri: ${ORDER_URL:http://order-service:9003}
+          uri: ${ORDER_URL}
           predicates: [ Path=/api/orders/** ]
 
 logging:

--- a/backend/auth-service/src/main/resources/application.yml
+++ b/backend/auth-service/src/main/resources/application.yml
@@ -1,13 +1,13 @@
-server: { port: 8080 }
+server: { port: ${SERVER_PORT:8080} }
 spring:
   application: { name: auth-service }
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
   jpa: { "hibernate": { "ddl-auto": "validate" }, "properties": { "hibernate": { "dialect": "org.hibernate.dialect.PostgreSQLDialect" } } }
   flyway: { "enabled": true,"locations": "classpath:db/migration","schemas": "easyshop","create-schemas": true }
-jwt: { "secret": "${JWT_SECRET:change-me}","ttlMinutes": 60 }
+jwt: { "secret": "${JWT_SECRET}","ttlMinutes": ${JWT_TTL_MINUTES:60} }
 
 logging:
   pattern:

--- a/backend/order-service/src/main/resources/application.yml
+++ b/backend/order-service/src/main/resources/application.yml
@@ -1,15 +1,15 @@
-server: { port: 9003 }
+server: { port: ${SERVER_PORT:9003} }
 spring:
   application: { name: order-service }
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
   jpa: { "hibernate": { "ddl-auto": "validate" }, "properties": { "hibernate": { "dialect": "org.hibernate.dialect.PostgreSQLDialect" } } }
   flyway: { "enabled": true,"locations": "classpath:db/migration","schemas": "easyshop","create-schemas": true }
-jwt: { "secret": "${JWT_SECRET:change-me}","ttlMinutes": 60 }
+jwt: { "secret": "${JWT_SECRET}","ttlMinutes": ${JWT_TTL_MINUTES:60} }
 product:
-  base-url: ${PRODUCT_BASE_URL:http://product-service:9002}
+  base-url: ${PRODUCT_BASE_URL}
 
 logging:
   pattern:

--- a/backend/product-service/src/main/resources/application.yml
+++ b/backend/product-service/src/main/resources/application.yml
@@ -1,13 +1,13 @@
-server: { port: 9002 }
+server: { port: ${SERVER_PORT:9002} }
 spring:
   application: { name: product-service }
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/postgres}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
   jpa: { "hibernate": { "ddl-auto": "validate" }, "properties": { "hibernate": { "dialect": "org.hibernate.dialect.PostgreSQLDialect" } } }
   flyway: { "enabled": true,"locations": "classpath:db/migration","schemas": "easyshop","create-schemas": true }
-jwt: { "secret": "${JWT_SECRET:change-me}","ttlMinutes": 60 }
+jwt: { "secret": "${JWT_SECRET}","ttlMinutes": ${JWT_TTL_MINUTES:60} }
 
 logging:
   pattern:


### PR DESCRIPTION
## Summary
- externalize backend service config to environment variables
- add env var configuration section to README

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fac803f4832eac2c2a05025446e9