### PR TITLE
Add gitignore files for backend services

### DIFF
--- a/backend/api-gateway/.gitignore
+++ b/backend/api-gateway/.gitignore
@@ -1,0 +1,15 @@
+# сборка
+target/
+*.jar
+*.class
+
+# конфигурация
+.env
+.env.*
+*.log
+
+# IDE/OS
+.idea/
+*.iml
+.vscode/
+.DS_Store

--- a/backend/auth-service/.gitignore
+++ b/backend/auth-service/.gitignore
@@ -1,0 +1,15 @@
+# сборка
+target/
+*.jar
+*.class
+
+# конфигурация
+.env
+.env.*
+*.log
+
+# IDE/OS
+.idea/
+*.iml
+.vscode/
+.DS_Store

--- a/backend/order-service/.gitignore
+++ b/backend/order-service/.gitignore
@@ -1,0 +1,15 @@
+# сборка
+target/
+*.jar
+*.class
+
+# конфигурация
+.env
+.env.*
+*.log
+
+# IDE/OS
+.idea/
+*.iml
+.vscode/
+.DS_Store

--- a/backend/product-service/.gitignore
+++ b/backend/product-service/.gitignore
@@ -1,0 +1,15 @@
+# сборка
+target/
+*.jar
+*.class
+
+# конфигурация
+.env
+.env.*
+*.log
+
+# IDE/OS
+.idea/
+*.iml
+.vscode/
+.DS_Store


### PR DESCRIPTION
## Summary
- add standard `.gitignore` files to backend api-gateway, auth-service, order-service, and product-service modules

## Testing
- `mvn -q test` *(fails: Network is unreachable for org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b6009cfba4832e9dbe84e4691cd08d