### PR TITLE
Add production env example and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ npm-debug.log*
 .vscode/
 /.env.example
 backend/*/.env
+
+infra/prod/.env

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cp infra/prod/.env.example infra/prod/.env
 Перед сборкой установите переменные окружения `GITHUB_ACTOR` и `GITHUB_TOKEN`.
 
 ```bash
-DOCKER_BUILDKIT=1 docker compose --env-file infra/prod/.env.prod -f infra/prod/docker-compose.prod.yml build
+DOCKER_BUILDKIT=1 docker compose --env-file infra/prod/.env -f infra/prod/docker-compose.prod.yml build
 ```
 
 ## Сборка микросервисов отдельно

--- a/infra/prod/.env.example
+++ b/infra/prod/.env.example
@@ -1,0 +1,9 @@
+GITHUB_ACTOR=your_github_username
+GITHUB_TOKEN=your_github_token
+DB_URL=jdbc:postgresql://db:5432/easyshop
+DB_USER=postgres
+DB_PASSWORD=postgres
+JWT_SECRET=your_jwt_secret
+AUTH_URL=http://auth-service:8080
+PRODUCT_URL=http://product-service:8080
+ORDER_URL=http://order-service:8080


### PR DESCRIPTION
## Summary
- add infra/prod/.env.example covering GitHub, DB, JWT and service URLs
- document using infra/prod/.env for production docker compose
- ignore actual infra/prod/.env in git

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `mvn -f backend/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b61bdf73dc832eaa5bea692eebc8ce