### PR TITLE
chore: track env example and ignore real env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ npm-debug.log*
 .DS_Store
 .idea/
 .vscode/
-/.env.example
+
+# Environment
+/.env
+infra/prod/.env
 backend/*/.env


### PR DESCRIPTION
## Summary
- stop ignoring `.env.example`
- ignore real environment files like `.env` and `infra/prod/.env`

## Testing
- `npm test` *(fails: Missing script "test"*)
- `mvn -q -f backend/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b61be62ee4832e95d3383d8417292f