### PR TITLE
Add auth-service application configuration

### DIFF
--- a/backend/auth-service/src/main/resources/application.yml
+++ b/backend/auth-service/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+server:
+  port: 9001
+spring:
+  application:
+    name: auth-service
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        default_schema: easyshop
+  flyway:
+    locations: classpath:db/migration
+    default-schema: easyshop
+    enabled: true
+jwt:
+  secret: ${JWT_SECRET}
+  ttlMinutes: ${JWT_TTL_MINUTES:60}
+logging:
+  pattern:
+    level: "%5p [trace:%X{traceId}]"


### PR DESCRIPTION
## Summary
- add YAML config for auth-service with datasource, Flyway, JWT, and logging settings

## Testing
- `mvn -q -f backend/auth-service/pom.xml test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b03cc9b8832eb72957720bec28a3