### PR TITLE
Add order-service application configuration

### DIFF
--- a/backend/order-service/src/main/resources/application.yml
+++ b/backend/order-service/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+server:
+  port: 9003
+spring:
+  application:
+    name: order-service
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        default_schema: easyshop
+  flyway:
+    locations: classpath:db/migration
+    default-schema: easyshop
+    enabled: true
+jwt:
+  secret: ${JWT_SECRET}
+logging:
+  pattern:
+    level: "%5p [trace:%X{traceId}]"


### PR DESCRIPTION
## Summary
- add `application.yml` for order-service configuring server port, datasource, JPA, Flyway, JWT, and logging

## Testing
- `mvn -q -pl order-service -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3 from/to github)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b0443fd8832ead81783d5e68804e