### PR TITLE
Api gateway product service unavailable

### DIFF
--- a/backend/api-gateway/pom.xml
+++ b/backend/api-gateway/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/backend/api-gateway/src/main/java/com/easyshop/gateway/config/GatewayRoutesConfig.java
+++ b/backend/api-gateway/src/main/java/com/easyshop/gateway/config/GatewayRoutesConfig.java
@@ -1,5 +1,6 @@
 package com.easyshop.gateway.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
@@ -8,15 +9,24 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class GatewayRoutesConfig {
 
+    @Value("${AUTH_URL:http://auth-service:9001}")
+    private String authUrl;
+
+    @Value("${PRODUCT_URL:http://product-service:9002}")
+    private String productUrl;
+
+    @Value("${PURCHASE_URL:http://purchase-service:9003}")
+    private String purchaseUrl;
+
     @Bean
     public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes()
                 .route("auth", r -> r.path("/api/auth/**")
-                        .uri("lb://auth-service"))
+                        .uri(authUrl))
                 .route("products", r -> r.path("/api/products/**")
-                        .uri("lb://product-service"))
+                        .uri(productUrl))
                 .route("purchases", r -> r.path("/api/purchases/**")
-                        .uri("lb://purchase-service"))
+                        .uri(purchaseUrl))
                 .build();
     }
 }


### PR DESCRIPTION
Configure API Gateway to use direct HTTP URLs for microservices and remove the unused load balancer dependency.

The API Gateway was configured to use `lb://` URIs, expecting a service discovery mechanism (like Eureka), but none was present in the Docker Compose setup. This resulted in `503 SERVICE_UNAVAILABLE` errors. By switching to direct HTTP URLs (e.g., `http://auth-service:9001`) and removing the load balancer dependency, the Gateway now correctly routes requests using Docker's internal networking.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ee272fb-9c0a-43ac-9729-9a542586a262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ee272fb-9c0a-43ac-9729-9a542586a262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

